### PR TITLE
Update NCMEC phone number format

### DIFF
--- a/KidsIdKit.Shared/Pages/info/InfoHyperlink.cs
+++ b/KidsIdKit.Shared/Pages/info/InfoHyperlink.cs
@@ -6,7 +6,7 @@ namespace KidsIdKit.Shared.Pages.info
     {
         public static MarkupString ContactTheNationalCenterForMissingAndExploitedChildren()
         {
-            var userFriendlyPhoneLink = GetPhoneLink("1-800-843-5678");
+            var userFriendlyPhoneLink = GetPhoneLink("800-843-5678");
             return (MarkupString)$"Contact the National Center for Missing and Exploited Children (NCMEC) at 1-800-THE-LOST ({userFriendlyPhoneLink}) to register your child";
         }
 

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
@@ -47,7 +47,7 @@ If you are outside the state of Minnesota, call AMECO at
     <li>
       Call and report this to the police.
     </li>
-    <li>Contact the National Center for Missing and Exploited Children (NCMEC) at 1-800-THE-LOST (<a href=""tel:+118008435678"">1-800-843-5678</a>) to register your child, as well as AMECO at <a href=""tel:+18772632620"">(877) 263-2620</a>
+    <li>Contact the National Center for Missing and Exploited Children (NCMEC) at 1-800-THE-LOST (<a href=""tel:+18008435678"">800-843-5678</a>) to register your child, as well as AMECO at <a href=""tel:+18772632620"">(877) 263-2620</a>
       for the AMECO-affiliated organization nearest you.
     </li>
   </ul>


### PR DESCRIPTION
Changed the phone number for the National Center for Missing and Exploited Children (NCMEC) from "1-800-843-5678" to "800-843-5678" in `InfoHyperlink.cs` and `AbductionTests.razor`. This update removes the "1-" prefix from the displayed text and hyperlink.

All hyperlinks and phone links now work perfectly on the Abduction page.