### PR TITLE
Ability to toggle Minnesota-related info. on and off.

### DIFF
--- a/KidsIdKit.Shared/Pages/info/Abduction.razor
+++ b/KidsIdKit.Shared/Pages/info/Abduction.razor
@@ -11,14 +11,27 @@
 
         Copilot also suggested the following: "(like the "Parental Abduction Prevention Tips" section) so that the page is not so long. I think that would be a good idea." *@
 
-    <p>
-        If you live in Minnesota, tell them you believe that he or she has violated @MinnesotaStateStatuteHyperlink("609.26") (all 50 states have laws that make it a felony to take a child with the purpose of depriving a parent of their parental rights).
-    </p>
-    <p>
-        Under Minnesota law, it is a crime for a parent to take a child even if they have sole of joint custody or if custody has not been determined. This is a complicated law and many police officers are not familiar with it. If you have trouble filing a police report, contact @InfoHyperlink.MissingChildrenMinnesotaWebsite() right away. If you have reason to believe that the parent or family member that took the child may take them out of the United States, please refer to the <NavLink href="/info/international">International Child Abduction</NavLink> section of this app as well.
-    </p>
-    <p>
-        If you are outside the state of Minnesota, call <PhoneLinkComponent phoneLink="phoneLink" /></p>
+    <button class="btn btn-primary" @onclick="ToggleMinnesotaSection">
+        @(ExpandMinnesotaSection ? "Hide Minnesota-related info." : "Show Minnesota-related info.")
+    </button>
+
+    @if (ExpandMinnesotaSection)
+    {
+        <p>
+            If you live in Minnesota, tell them you believe that he or she has violated @MinnesotaStateStatuteHyperlink("609.26") (all 50 states have laws that make it a felony to take a child with the purpose of depriving a parent of their parental rights).
+        </p>
+        <p>
+            Under Minnesota law, it is a crime for a parent to take a child even if they have sole of joint custody or if custody has not been determined. This is a complicated law and many police officers are not familiar with it. If you have trouble filing a police report, contact @InfoHyperlink.MissingChildrenMinnesotaWebsite() right away. If you have reason to believe that the parent or family member that took the child may take them out of the United States, please refer to the <NavLink href="/info/international">International Child Abduction</NavLink> section of this app as well.
+        </p>
+    }
+
+    @if (ExpandOutsideMinnesotaSection)
+    {
+        <p>
+            If you are outside the state of Minnesota, call <PhoneLinkComponent phoneLink="phoneLink" />
+        </p>
+    }
+
     <p>
         If parents were not married when the child was conceived or born, or if parents have never been married, custody is automatically with the mother under Minnesota law. The father does not have custody unless there is a custody order or agreement on file with the court. @((MarkupString)MinnesotaStateStatuteDetailsAreHere("257.541")).
     </p>
@@ -72,6 +85,11 @@ National Crime Information Center (NCIC) Missing Person’s file immediately upo
     private string amecoPhoneNumber = "(877) 263-2620";
     private MarkupString? phoneLink;
     private string minnesotaLegislatureOfficeOfTheRevisorOfStatutesUrl = "https://www.revisor.mn.gov/statutes/";
+
+    private bool ExpandMinnesotaSection = true; // This can be toggled to show/hide the Minnesota section
+    private void ToggleMinnesotaSection() => ExpandMinnesotaSection = !ExpandMinnesotaSection;
+
+    private bool ExpandOutsideMinnesotaSection = true; // This can be toggled to show/hide the outside Minnesota section
 
     protected override void OnInitialized()
     {

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
@@ -18,6 +18,7 @@
   <p>
     <strong>If an estranged parent or former spouse has abducted your child, call the police immediately.</strong>
   </p>
+  <button class='btn btn-primary' >Hide Minnesota-related info.</button>
   <p>
     If you live in Minnesota, tell them you believe that he or she has violated
     <a href=""https://www.revisor.mn.gov/statutes/?id=609.26"">MN State Statute 609.26</a>
@@ -86,5 +87,7 @@ National Crime Information Center (NCIC) Missing Person’s file immediately upo
         cut.MarkupMatches(expectedMarkup);
     }
 }
+
+// TODO: need tests for the 'ExpandOutsideMinnesotaSection' toggle functionality
 
 // TODO: Art - rename 'Abduction' to 'Abductions'


### PR DESCRIPTION
This is somewhat of a PoC (Proof of Concept) PR in that would like to get feedback on ...:

1. ... the look-and-feel of the new button
2. ... the section (e.g., is all the Minnesota-related info. correctly conditionalized and is all the outside-Minnesota-related info. correctly conditionalized - keeping in mind that I have not implemented the expand/collapse [show/hide] button for the outside-Minnesota-related info.)