### PR TITLE
73 'info' to 'Info'

### DIFF
--- a/KidsIdKit.Shared/Pages/info/Abduction.razor
+++ b/KidsIdKit.Shared/Pages/info/Abduction.razor
@@ -11,14 +11,27 @@
 
         Copilot also suggested the following: "(like the "Parental Abduction Prevention Tips" section) so that the page is not so long. I think that would be a good idea." *@
 
-    <p>
-        If you live in Minnesota, tell them you believe that he or she has violated @MinnesotaStateStatuteHyperlink("609.26") (all 50 states have laws that make it a felony to take a child with the purpose of depriving a parent of their parental rights).
-    </p>
-    <p>
-        Under Minnesota law, it is a crime for a parent to take a child even if they have sole of joint custody or if custody has not been determined. This is a complicated law and many police officers are not familiar with it. If you have trouble filing a police report, contact @InfoHyperlink.MissingChildrenMinnesotaWebsite() right away. If you have reason to believe that the parent or family member that took the child may take them out of the United States, please refer to the <NavLink href="/info/international">International Child Abduction</NavLink> section of this app as well.
-    </p>
-    <p>
-        If you are outside the state of Minnesota, call <PhoneLinkComponent phoneLink="phoneLink" /></p>
+    <button class="btn btn-primary" @onclick="ToggleMinnesotaSection">
+        @(ExpandMinnesotaSection ? "Hide Minnesota-related info." : "Show Minnesota-related info.")
+    </button>
+
+    @if (ExpandMinnesotaSection)
+    {
+        <p>
+            If you live in Minnesota, tell them you believe that he or she has violated @MinnesotaStateStatuteHyperlink("609.26") (all 50 states have laws that make it a felony to take a child with the purpose of depriving a parent of their parental rights).
+        </p>
+        <p>
+            Under Minnesota law, it is a crime for a parent to take a child even if they have sole of joint custody or if custody has not been determined. This is a complicated law and many police officers are not familiar with it. If you have trouble filing a police report, contact @InfoHyperlink.MissingChildrenMinnesotaWebsite() right away. If you have reason to believe that the parent or family member that took the child may take them out of the United States, please refer to the <NavLink href="/info/international">International Child Abduction</NavLink> section of this app as well.
+        </p>
+    }
+
+    @if (ExpandOutsideMinnesotaSection)
+    {
+        <p>
+            If you are outside the state of Minnesota, call <PhoneLinkComponent phoneLink="phoneLink" />
+        </p>
+    }
+
     <p>
         If parents were not married when the child was conceived or born, or if parents have never been married, custody is automatically with the mother under Minnesota law. The father does not have custody unless there is a custody order or agreement on file with the court. @((MarkupString)MinnesotaStateStatuteDetailsAreHere("257.541")).
     </p>
@@ -72,6 +85,11 @@ National Crime Information Center (NCIC) Missing Person’s file immediately upo
     private string amecoPhoneNumber = "(877) 263-2620";
     private MarkupString? phoneLink;
     private string minnesotaLegislatureOfficeOfTheRevisorOfStatutesUrl = "https://www.revisor.mn.gov/statutes/";
+
+    private bool ExpandMinnesotaSection = true; // This can be toggled to show/hide the Minnesota section
+    private void ToggleMinnesotaSection() => ExpandMinnesotaSection = !ExpandMinnesotaSection;
+
+    private bool ExpandOutsideMinnesotaSection = true; // This can be toggled to show/hide the outside Minnesota section
 
     protected override void OnInitialized()
     {

--- a/KidsIdKit.Shared/Pages/info/Abduction.razor
+++ b/KidsIdKit.Shared/Pages/info/Abduction.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/abduction"
+﻿@page "/Info/abduction"
 
 <InfoPage />
 
@@ -21,7 +21,7 @@
             If you live in Minnesota, tell them you believe that he or she has violated @MinnesotaStateStatuteHyperlink("609.26") (all 50 states have laws that make it a felony to take a child with the purpose of depriving a parent of their parental rights).
         </p>
         <p>
-            Under Minnesota law, it is a crime for a parent to take a child even if they have sole of joint custody or if custody has not been determined. This is a complicated law and many police officers are not familiar with it. If you have trouble filing a police report, contact @InfoHyperlink.MissingChildrenMinnesotaWebsite() right away. If you have reason to believe that the parent or family member that took the child may take them out of the United States, please refer to the <NavLink href="/info/international">International Child Abduction</NavLink> section of this app as well.
+            Under Minnesota law, it is a crime for a parent to take a child even if they have sole of joint custody or if custody has not been determined. This is a complicated law and many police officers are not familiar with it. If you have trouble filing a police report, contact @InfoHyperlink.MissingChildrenMinnesotaWebsite() right away. If you have reason to believe that the parent or family member that took the child may take them out of the United States, please refer to the <NavLink href="/Info/international">International Child Abduction</NavLink> section of this app as well.
         </p>
     }
 

--- a/KidsIdKit.Shared/Pages/info/Abouthtbox.razor
+++ b/KidsIdKit.Shared/Pages/info/Abouthtbox.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/abouthtbox"
+﻿@page "/Info/abouthtbox"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/Aboutmcm.razor
+++ b/KidsIdKit.Shared/Pages/info/Aboutmcm.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/aboutmcm"
+﻿@page "/Info/aboutmcm"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/Amberalert.razor
+++ b/KidsIdKit.Shared/Pages/info/Amberalert.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/amberalert"
+﻿@page "/Info/amberalert"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/DNA.razor
+++ b/KidsIdKit.Shared/Pages/info/DNA.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/dna"
+﻿@page "/Info/dna"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/DisasterPreparation.razor
+++ b/KidsIdKit.Shared/Pages/info/DisasterPreparation.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/disasterpreparation"
+﻿@page "/Info/disasterpreparation"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/HyperlinkHelper.cs
+++ b/KidsIdKit.Shared/Pages/info/HyperlinkHelper.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 
-namespace KidsIdKit.Shared.Pages.info
+namespace KidsIdKit.Shared.Pages.Info
 {
     public static class HyperlinkHelper
     {

--- a/KidsIdKit.Shared/Pages/info/Info.razor
+++ b/KidsIdKit.Shared/Pages/info/Info.razor
@@ -1,4 +1,4 @@
-﻿@page "/info"
+﻿@page "/Info"
 
 <h1>Information</h1>
 
@@ -27,6 +27,6 @@
 @foreach (var link in links)
 {
     <div>
-        <a class="link-primary" href="/info/@link.Href">@link.Text</a>
+        <a class="link-primary" href="/Info/@link.Href">@link.Text</a>
     </div>
 }

--- a/KidsIdKit.Shared/Pages/info/InfoConstants.cs
+++ b/KidsIdKit.Shared/Pages/info/InfoConstants.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 
-namespace KidsIdKit.Shared.Pages.info
+namespace KidsIdKit.Shared.Pages.Info
 {
     public static class InfoConstants
     {

--- a/KidsIdKit.Shared/Pages/info/InfoHyperlink.cs
+++ b/KidsIdKit.Shared/Pages/info/InfoHyperlink.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 
-namespace KidsIdKit.Shared.Pages.info
+namespace KidsIdKit.Shared.Pages.Info
 {
     public class InfoHyperlink
     {
@@ -13,7 +13,7 @@ namespace KidsIdKit.Shared.Pages.info
         public static MarkupString InfoLink(string page, string text)
         {
             var doubleQuote = InfoConstants.DOUBLE_QUOTE;
-            return (MarkupString)$"<div><a class={doubleQuote}link-primary{doubleQuote} href={doubleQuote}/info/{page}{doubleQuote}>{text}</a></div>";
+            return (MarkupString)$"<div><a class={doubleQuote}link-primary{doubleQuote} href={doubleQuote}/Info/{page}{doubleQuote}>{text}</a></div>";
         }
 
         public static MarkupString MissingChildrenMinnesotaWebsite()

--- a/KidsIdKit.Shared/Pages/info/International.razor
+++ b/KidsIdKit.Shared/Pages/info/International.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/international"
+﻿@page "/Info/international"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/International.razor.cs
+++ b/KidsIdKit.Shared/Pages/info/International.razor.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Components;
 
-namespace KidsIdKit.Shared.Pages.info
+namespace KidsIdKit.Shared.Pages.Info
 {
     public partial class International : ComponentBase
     {

--- a/KidsIdKit.Shared/Pages/info/Missing.razor
+++ b/KidsIdKit.Shared/Pages/info/Missing.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/missing"
+﻿@page "/Info/missing"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/Runaway.razor
+++ b/KidsIdKit.Shared/Pages/info/Runaway.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/runaway"
+﻿@page "/Info/runaway"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Pages/info/Safety.razor
+++ b/KidsIdKit.Shared/Pages/info/Safety.razor
@@ -1,4 +1,4 @@
-﻿@page "/info/safety"
+﻿@page "/Info/safety"
 
 <InfoPage />
 

--- a/KidsIdKit.Shared/Shared/InfoPage.razor
+++ b/KidsIdKit.Shared/Shared/InfoPage.razor
@@ -1,1 +1,1 @@
-﻿<div><a href="/info" class="link-dark">Back</a></div>
+﻿<div><a href="/Info" class="link-dark">Back</a></div>

--- a/KidsIdKit.Shared/Shared/NavMenu.razor
+++ b/KidsIdKit.Shared/Shared/NavMenu.razor
@@ -15,7 +15,7 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="info">
+            <NavLink class="nav-link" href="Info">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Information
             </NavLink>
         </div>

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
@@ -1,5 +1,5 @@
 ﻿@using Bunit.Diffing
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext
@@ -28,7 +28,7 @@
     Under Minnesota law, it is a crime for a parent to take a child even if they have sole of joint custody or if custody has not been determined. This is a complicated law and many police officers are not familiar with it. If you have trouble filing a police report, contact
     <a href=""https://missingchildrenmn.com/contact/"">Missing Children Minnesota</a>
     right away. If you have reason to believe that the parent or family member that took the child may take them out of the United States, please refer to the
-    <a href=""/info/international"">International Child Abduction</a>
+    <a href=""/Info/international"">International Child Abduction</a>
     section of this app as well.
   </p>
   <p>

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbductionTests.razor
@@ -18,6 +18,7 @@
   <p>
     <strong>If an estranged parent or former spouse has abducted your child, call the police immediately.</strong>
   </p>
+  <button class='btn btn-primary' >Hide Minnesota-related info.</button>
   <p>
     If you live in Minnesota, tell them you believe that he or she has violated
     <a href=""https://www.revisor.mn.gov/statutes/?id=609.26"">MN State Statute 609.26</a>
@@ -86,5 +87,7 @@ National Crime Information Center (NCIC) Missing Person’s file immediately upo
         cut.MarkupMatches(expectedMarkup);
     }
 }
+
+// TODO: need tests for the 'ExpandOutsideMinnesotaSection' toggle functionality
 
 // TODO: Art - rename 'Abduction' to 'Abductions'

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbouthtboxTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AbouthtboxTests.razor
@@ -1,5 +1,5 @@
 ﻿@using Bunit.Diffing
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AboutmcmTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AboutmcmTests.razor
@@ -1,5 +1,5 @@
 ﻿@using Bunit.Diffing
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AmberalertTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/AmberalertTests.razor
@@ -1,5 +1,5 @@
 ﻿@using Bunit.Diffing
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/DNATests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/DNATests.razor
@@ -1,5 +1,5 @@
 ﻿@using Bunit.Diffing
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/DisasterPreparationTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/DisasterPreparationTests.razor
@@ -1,5 +1,5 @@
 ﻿@using Bunit.Diffing
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/HtmlHelper.cs
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/HtmlHelper.cs
@@ -6,7 +6,7 @@ namespace KidsIdKit.Tests.Utilities
         {
             return $@"
                 <div>
-                    <a href=""/info"" class=""link-dark"">Back</a>
+                    <a href=""/Info"" class=""link-dark"">Back</a>
                 </div>";
         }
     }

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/InternationalTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/InternationalTests.razor
@@ -1,5 +1,5 @@
 ﻿@using Bunit.Diffing
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/MissingTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/MissingTests.razor
@@ -1,5 +1,5 @@
 ﻿@* @using Bunit.Diffing *@
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/RunawayTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/RunawayTests.razor
@@ -1,5 +1,5 @@
 ﻿@* @using Bunit.Diffing *@
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext

--- a/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/SafetyTests.razor
+++ b/KidsIdKit.Tests/KidsIdKit.Shared/Pages/info/SafetyTests.razor
@@ -1,5 +1,5 @@
 ﻿@* @using Bunit.Diffing *@
-@using KidsIdKit.Shared.Pages.info
+@using KidsIdKit.Shared.Pages.Info
 @using KidsIdKit.Tests.Utilities
 
 @inherits TestContext


### PR DESCRIPTION
Replaced all references to 'info' with 'Info' (for consistency with other casing).