### PR TITLE
Support building/deploying Android

### DIFF
--- a/KidsIdKit.Core/KidsIdKit.Core.csproj
+++ b/KidsIdKit.Core/KidsIdKit.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+++ b/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
@@ -1,10 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
+
+		<!-- Bypass Xcode version check for newer Xcode versions -->
+		<_XamarinEnforceMinimumVersion>false</_XamarinEnforceMinimumVersion>
 
 		<!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
@@ -26,7 +29,7 @@
 		<ApplicationTitle>KidsIdKit</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.kidsidkit</ApplicationId>
+		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 		<ApplicationIdGuid>86DA4F61-F8E9-4EDE-9B0C-BA2DAA3ADAFD</ApplicationIdGuid>
 
 		<!-- Versions -->
@@ -44,35 +47,40 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
+		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
+		<CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
+		<CodesignKey>Apple Development: Perry Hoekstra (MSY5KBLRTR)</CodesignKey>
+		<CodesignProvision>Automatic</CodesignProvision>
+		<MtouchLink>SdkOnly</MtouchLink>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
+		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
+		<CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-maccatalyst|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-maccatalyst|AnyCPU'">
-		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.19041.0|AnyCPU'">
-		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.19041.0|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows10.0.19041.0|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 	</PropertyGroup>
 

--- a/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+++ b/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
@@ -6,9 +6,6 @@
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 
-		<!-- Bypass Xcode version check for newer Xcode versions -->
-		<_XamarinEnforceMinimumVersion>false</_XamarinEnforceMinimumVersion>
-
 		<!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
             When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifer>.
@@ -62,6 +59,8 @@
 		<!-- Example: <CodesignKey>Apple Development: Your Name (TEAMID)</CodesignKey> -->
 		<CodesignProvision>Automatic</CodesignProvision>
 		<MtouchLink>SdkOnly</MtouchLink>
+		<!-- Bypass Xcode version check for newer Xcode versions during development -->
+		<_XamarinEnforceMinimumVersion>false</_XamarinEnforceMinimumVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">

--- a/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+++ b/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
@@ -58,7 +58,8 @@
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
 		<CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
-		<CodesignKey>Apple Development: Perry Hoekstra (MSY5KBLRTR)</CodesignKey>
+		<!-- Update CodesignKey with your Apple Development certificate name -->
+		<!-- Example: <CodesignKey>Apple Development: Your Name (TEAMID)</CodesignKey> -->
 		<CodesignProvision>Automatic</CodesignProvision>
 		<MtouchLink>SdkOnly</MtouchLink>
 	</PropertyGroup>

--- a/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+++ b/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
@@ -37,7 +37,7 @@
 		<Copyright>Copyright 2023 Missing Children Minnesota</Copyright>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>

--- a/KidsIdKit.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/KidsIdKit.Mobile/Platforms/Android/AndroidManifest.xml
@@ -3,4 +3,12 @@
     <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Read photos on Android 13+ -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- Read storage on Android 12 and below -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <!-- Write storage on Android 9 and below -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 </manifest>

--- a/KidsIdKit.Mobile/Platforms/iOS/Entitlements.plist
+++ b/KidsIdKit.Mobile/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Add entitlements here as needed for your app -->
+    <!-- Example entitlements for file sharing and iCloud if needed in the future -->
+</dict>
+</plist>

--- a/KidsIdKit.Mobile/Platforms/iOS/Info.plist
+++ b/KidsIdKit.Mobile/Platforms/iOS/Info.plist
@@ -28,5 +28,11 @@
     </array>
     <key>XSAppIconAssets</key>
     <string>Assets.xcassets/appicon.appiconset</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Kids ID Kit needs access to your camera to take photos of your children for their ID records.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Kids ID Kit needs access to your photo library to save and manage photos of your children.</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>Kids ID Kit needs permission to save photos to your photo library.</string>
 </dict>
 </plist>

--- a/KidsIdKit.Tests/KidsIdKit.Tests.csproj
+++ b/KidsIdKit.Tests/KidsIdKit.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/KidsIdKit.Web/KidsIdKit.Web.csproj
+++ b/KidsIdKit.Web/KidsIdKit.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>

--- a/README_ANDROID.md
+++ b/README_ANDROID.md
@@ -1,0 +1,315 @@
+# Android Deployment Guide for KidsIdKit
+
+This guide provides step-by-step instructions for building and deploying the KidsIdKit .NET MAUI Blazor app to Android devices and Google Play.
+
+## Quick Start
+
+Already have everything set up? Jump straight to deployment:
+
+```bash
+# Deploy to your connected Android device (from project root)
+./scripts/deploy-android-device.sh
+
+# Or test in emulator
+./scripts/run-android-emulator.sh
+```
+
+See [scripts/README.md](scripts/README.md) for all available commands.
+
+---
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Prerequisites](#prerequisites)
+- [Initial Setup](#initial-setup)
+- [Development Build (Testing on Your Device)](#development-build-testing-on-your-device)
+- [Google Play Deployment](#google-play-deployment)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+### Required Software
+
+1. **macOS** (or Windows/Linux - Android development is cross-platform)
+2. **Java JDK 17** - Required by Android SDK tooling:
+   ```bash
+   brew install --cask temurin@17
+   ```
+3. **Android SDK** - Install via Android command-line tools:
+   ```bash
+   brew install --cask android-commandlinetools
+   ```
+4. **.NET 10.0 SDK** - Install via Homebrew:
+   ```bash
+   brew install --cask dotnet-sdk
+   ```
+5. **.NET MAUI Workload**:
+   ```bash
+   sudo dotnet workload install maui
+   ```
+
+### Verify Installation
+
+```bash
+# Check Java version
+java -version
+# Should show: openjdk version "17.x.x"
+
+# Check adb version
+adb version
+# Should show: Android Debug Bridge version x.x.x
+
+# Check .NET version
+dotnet --version
+# Should show: 10.0.200 or higher
+
+# Check MAUI workload
+dotnet workload list
+# Should show: maui
+
+# Or run the setup check script
+./scripts/check-android-setup.sh
+```
+
+**Note:** These commands assume `dotnet` and `adb` are in your PATH. After installing:
+- Restart your terminal, or
+- Add to PATH manually:
+  ```bash
+  # Add to ~/.zshrc
+  export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+  export ANDROID_HOME="$HOME/Library/Android/sdk"
+  export PATH="$ANDROID_HOME/platform-tools:$PATH"
+  ```
+  Then reload: `source ~/.zshrc`
+
+---
+
+## Initial Setup
+
+### Step 1: Install Android SDK Components
+
+After installing the Android command-line tools, install the required SDK packages:
+
+```bash
+# Accept all licenses
+yes | sdkmanager --licenses
+
+# Install required components
+sdkmanager "platform-tools" "platforms;android-36" "platforms;android-35" "build-tools;36.0.0" "build-tools;35.0.0"
+
+# Optional: Install emulator support
+sdkmanager "emulator" "system-images;android-35;google_apis;arm64-v8a"
+```
+
+### Step 2: Enable Developer Options on Android Device
+
+1. Go to **Settings → About Phone**
+2. Tap **Build Number** 7 times rapidly
+   - You'll see "You are now a developer!" message
+3. Go back to **Settings → Developer Options** (may be under System)
+4. Enable **USB Debugging**
+5. Connect your device via USB
+6. When prompted on device, tap **"Allow USB Debugging"** and check "Always allow from this computer"
+
+### Step 3: Verify Device Connection
+
+```bash
+adb devices
+```
+
+You should see your device listed as `device` (not `unauthorized`):
+```
+List of devices attached
+ABC123DEF456    device
+```
+
+If you see `unauthorized`, check your phone for the USB debugging authorization prompt.
+
+---
+
+## Development Build (Testing on Your Device)
+
+### Using Convenience Scripts (Recommended)
+
+```bash
+# Check your Android development environment
+./scripts/check-android-setup.sh
+
+# Build for physical Android device
+./scripts/build-android-device.sh
+
+# Build and deploy to connected device
+./scripts/deploy-android-device.sh
+
+# Build for emulator
+./scripts/build-android-emulator.sh
+
+# Build and run in emulator
+./scripts/run-android-emulator.sh
+```
+
+### Using dotnet Commands Directly
+
+```bash
+# Navigate to project root
+cd /path/to/KidsIdKit
+
+# Build for physical device (arm64)
+dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-android \
+  -p:RuntimeIdentifier=android-arm64
+
+# Build and deploy to connected device
+dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -t:Run \
+  -f net10.0-android
+
+# Build for emulator (x64)
+dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-android \
+  -p:RuntimeIdentifier=android-x64
+```
+
+### App Permissions
+
+The app requests the following permissions at runtime:
+- **Camera** - To take photos of children for ID records
+- **Read Media Images** (Android 13+) - To access photo library
+- **Read External Storage** (Android 12 and below) - To access photos
+
+These will be requested the first time the relevant feature is used.
+
+---
+
+## Google Play Deployment
+
+### Prerequisites for Google Play Distribution
+
+1. **Google Play Developer Account** ($25 one-time fee)
+   - Register at: https://play.google.com/console/signup
+   - If Missing Children Minnesota has an existing Google Play account, request access
+
+2. **Signing Keystore** - A keystore file is required to sign release builds:
+   ```bash
+   # Generate a keystore (one-time setup - keep this file safe!)
+   keytool -genkeypair -v \
+     -keystore kidsidkit.keystore \
+     -alias kidsidkit \
+     -keyalg RSA \
+     -keysize 2048 \
+     -validity 10000
+   ```
+   **Important:** Never commit the keystore to git. Store it securely and back it up - losing it means you cannot update the app on Google Play.
+
+### Step 1: Build Release AAB
+
+Set signing environment variables and run the release script:
+
+```bash
+export ANDROID_SIGNING_KEY_STORE=/path/to/kidsidkit.keystore
+export ANDROID_SIGNING_KEY_ALIAS=kidsidkit
+export ANDROID_SIGNING_KEY_PASS=your_key_password
+export ANDROID_SIGNING_STORE_PASS=your_store_password
+
+./scripts/build-android-release.sh
+```
+
+Or using dotnet directly:
+
+```bash
+dotnet publish \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-android \
+  -c Release \
+  -p:AndroidPackageFormat=aab \
+  -p:AndroidKeyStore=true \
+  -p:AndroidSigningKeyStore=/path/to/kidsidkit.keystore \
+  -p:AndroidSigningKeyAlias=kidsidkit \
+  -p:AndroidSigningKeyPass=your_key_password \
+  -p:AndroidSigningStorePass=your_store_password
+```
+
+The `.aab` file will be in `KidsIdKit.Mobile/bin/Release/net10.0-android/`.
+
+### Step 2: Upload to Google Play Console
+
+1. Go to [Google Play Console](https://play.google.com/console)
+2. Select your app (or create a new one)
+3. Go to **Release → Production** (or Internal Testing for initial upload)
+4. Click **Create new release**
+5. Upload the `.aab` file
+6. Fill in release notes
+7. Review and submit
+
+---
+
+## Troubleshooting
+
+### "adb: command not found"
+
+Ensure Android SDK platform-tools are installed and in PATH:
+```bash
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$ANDROID_HOME/platform-tools:$PATH"
+source ~/.zshrc
+```
+
+### "No Android devices connected"
+
+1. Check USB cable is data-capable (not charge-only)
+2. Check USB Debugging is enabled on device
+3. Run `adb devices` and accept the authorization prompt on the device
+4. Try `adb kill-server && adb start-server`
+
+### "Android SDK directory could not be found"
+
+Set `ANDROID_HOME` environment variable:
+```bash
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+```
+Or pass it to the build:
+```bash
+dotnet build ... -p:AndroidSdkDirectory="$HOME/Library/Android/sdk"
+```
+
+### "Java not found" / XA5300 error
+
+Install JDK 17 and set JAVA_HOME:
+```bash
+brew install --cask temurin@17
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+```
+
+### Device shows as "unauthorized"
+
+1. Unlock your phone
+2. Check for the USB debugging authorization dialog
+3. Tap "Allow" and optionally check "Always allow from this computer"
+4. Run `adb devices` again
+
+### Build error: "SDK location not found"
+
+Run the setup check to diagnose:
+```bash
+./scripts/check-android-setup.sh
+```
+
+---
+
+## App Bundle Identifier
+
+The app uses bundle identifier: `com.missingchildrenmn.kidsidkit`
+
+This is configured in [KidsIdKit.Mobile.csproj](KidsIdKit.Mobile/KidsIdKit.Mobile.csproj) and matches the iOS bundle identifier for consistency.
+
+---
+
+## Minimum Android Version
+
+The app targets **Android 7.0 (API 24)** as the minimum version, covering approximately 97% of active Android devices.

--- a/README_IOS.md
+++ b/README_IOS.md
@@ -1,0 +1,457 @@
+# iOS Deployment Guide for KidsIdKit
+
+This guide provides step-by-step instructions for building and deploying the KidsIdKit .NET MAUI Blazor app to iOS devices and the App Store.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Initial Setup](#initial-setup)
+- [Development Build (Testing on Your Device)](#development-build-testing-on-your-device)
+- [App Store Deployment](#app-store-deployment)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+### Required Software
+
+1. **macOS** - iOS development requires a Mac
+2. **Xcode 26.2** - Download from [Apple Developer](https://developer.apple.com/download/)
+3. **.NET 10.0 SDK** - Install via Homebrew:
+   ```bash
+   brew install --cask dotnet-sdk
+   ```
+4. **.NET MAUI Workload**:
+   ```bash
+   sudo /usr/local/share/dotnet/dotnet workload install maui
+   ```
+
+### Verify Installation
+
+```bash
+# Check .NET version
+/usr/local/share/dotnet/dotnet --version
+# Should show: 10.0.200 or higher
+
+# Check MAUI workload
+/usr/local/share/dotnet/dotnet workload list
+# Should show: maui
+
+# Check Xcode version
+xcodebuild -version
+# Should show: Xcode 26.2
+```
+
+---
+
+## Initial Setup
+
+### 1. iOS Configuration Files
+
+The project already includes the necessary iOS configuration:
+
+- **Info.plist** ([KidsIdKit.Mobile/Platforms/iOS/Info.plist](KidsIdKit.Mobile/Platforms/iOS/Info.plist))
+  - Camera usage permission
+  - Photo library access permissions
+
+- **Entitlements.plist** ([KidsIdKit.Mobile/Platforms/iOS/Entitlements.plist](KidsIdKit.Mobile/Platforms/iOS/Entitlements.plist))
+  - iOS capabilities configuration
+
+- **KidsIdKit.Mobile.csproj** ([KidsIdKit.Mobile/KidsIdKit.Mobile.csproj](KidsIdKit.Mobile/KidsIdKit.Mobile.csproj))
+  - Bundle ID: `com.missingchildrenmn.kidsidkit`
+  - Code signing configuration
+
+### 2. Xcode Version Compatibility
+
+If you have Xcode 26.3 or newer, you need to use Xcode 26.2 for compatibility with the current .NET MAUI workload:
+
+```bash
+# Switch to Xcode 26.2
+sudo xcode-select --switch "/Applications/Xcode 26.2 .app"
+
+# Verify the switch
+xcodebuild -version
+```
+
+---
+
+## Development Build (Testing on Your Device)
+
+### Step 1: Generate Apple Development Certificate
+
+For free development (7-day certificate), you need to generate a development certificate:
+
+1. Open Xcode
+2. Create a new iOS project: **File → New → Project → iOS → App**
+3. Fill in details:
+   - Product Name: `TempApp`
+   - Team: Select or add your Apple ID
+   - Organization Identifier: `com.yourname`
+4. In project settings:
+   - Select the target
+   - Go to **"Signing & Capabilities"**
+   - Check **"Automatically manage signing"**
+   - Select your Apple ID as Team
+
+Xcode will automatically generate the development certificate.
+
+5. Verify certificate:
+   ```bash
+   security find-identity -v -p codesigning
+   ```
+   You should see: `"Apple Development: Your Name (TEAMID)"`
+
+### Step 2: Create Provisioning Profile
+
+1. In the same TempApp project in Xcode
+2. Change the Bundle Identifier to: `com.missingchildrenmn.kidsidkit`
+3. Build the project (⌘+B)
+4. This creates a provisioning profile for KidsIdKit
+
+5. Copy profiles to standard location:
+   ```bash
+   cp ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision \
+      ~/Library/MobileDevice/Provisioning\ Profiles/
+   ```
+
+### Step 3: Update Project Configuration
+
+The project should already be configured with your signing identity in [KidsIdKit.Mobile.csproj](KidsIdKit.Mobile/KidsIdKit.Mobile.csproj):
+
+```xml
+<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
+  <ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
+  <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
+  <CodesignKey>Apple Development: Your Name (TEAMID)</CodesignKey>
+  <CodesignProvision>Automatic</CodesignProvision>
+  <MtouchLink>SdkOnly</MtouchLink>
+</PropertyGroup>
+```
+
+Update the `CodesignKey` with your certificate name from Step 1.
+
+### Step 4: Enable Developer Mode on iPhone
+
+On iOS 16+, you must enable Developer Mode:
+
+1. On iPhone: **Settings → Privacy & Security → Developer Mode**
+2. Toggle **Developer Mode** to ON
+3. Restart when prompted
+4. After restart, tap **Turn On** and enter passcode
+
+### Step 5: Build and Deploy
+
+```bash
+# Navigate to project root
+cd /path/to/KidsIdKit
+
+# Build for iOS Simulator (testing without device)
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios
+
+# Build for physical device
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios \
+  -p:RuntimeIdentifier=ios-arm64
+
+# Deploy to connected iPhone
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -t:Run \
+  -f net10.0-ios \
+  -p:RuntimeIdentifier=ios-arm64 \
+  -p:_DeviceName="Your iPhone Name"
+```
+
+**Important:** Free development certificates expire after 7 days. You'll need to rebuild and redeploy after this period.
+
+---
+
+## App Store Deployment
+
+### Prerequisites for App Store Distribution
+
+1. **Apple Developer Program Membership** ($99/year)
+   - Organization account (for Missing Children Minnesota)
+   - Visit: https://developer.apple.com/programs/enroll/
+
+2. **Team Access**
+   - If Missing Children Minnesota has an Apple Developer account, request to be added as:
+     - **App Manager** (can manage apps, TestFlight, App Store submissions)
+     - **Developer** (can create certificates, test on devices)
+
+### Step 1: Register App ID
+
+1. Sign in to [Apple Developer Portal](https://developer.apple.com/account/)
+2. Navigate to **Certificates, Identifiers & Profiles**
+3. Click **Identifiers** → **+** button
+4. Select **App IDs** → **App**
+5. Configure:
+   - Description: `Kids ID Kit`
+   - Bundle ID: `com.missingchildrenmn.kidsidkit` (Explicit)
+   - Capabilities: Enable any needed (Camera, Photo Library are implicit)
+6. Click **Continue** → **Register**
+
+### Step 2: Create Distribution Certificate
+
+1. In **Certificates, Identifiers & Profiles** → **Certificates**
+2. Click **+** button
+3. Select **Apple Distribution**
+4. Follow prompts to create Certificate Signing Request (CSR)
+5. Upload CSR and download certificate
+6. Double-click downloaded certificate to install in Keychain
+
+### Step 3: Create Distribution Provisioning Profile
+
+1. In **Certificates, Identifiers & Profiles** → **Profiles**
+2. Click **+** button
+3. Select **App Store** under Distribution
+4. Select App ID: `com.missingchildrenmn.kidsidkit`
+5. Select Distribution certificate
+6. Download and install profile:
+   ```bash
+   cp ~/Downloads/*.mobileprovision \
+      ~/Library/MobileDevice/Provisioning\ Profiles/
+   ```
+
+### Step 4: Configure Release Build
+
+Update [KidsIdKit.Mobile.csproj](KidsIdKit.Mobile/KidsIdKit.Mobile.csproj) Release configuration:
+
+```xml
+<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
+  <ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
+  <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
+  <CodesignKey>Apple Distribution: Missing Children Minnesota (TEAMID)</CodesignKey>
+  <CodesignProvision>KidsIdKit Distribution Profile</CodesignProvision>
+  <MtouchLink>Full</MtouchLink>
+  <EnableAssemblyILStripping>true</EnableAssemblyILStripping>
+  <MtouchUseLlvm>true</MtouchUseLlvm>
+  <MtouchFloat32>true</MtouchFloat32>
+</PropertyGroup>
+```
+
+### Step 5: Build Release Archive
+
+```bash
+# Clean previous builds
+/usr/local/share/dotnet/dotnet clean
+
+# Build Release for App Store
+/usr/local/share/dotnet/dotnet publish \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios \
+  -c Release \
+  -p:ArchiveOnBuild=true \
+  -p:RuntimeIdentifier=ios-arm64
+```
+
+The archive will be created at:
+```
+KidsIdKit.Mobile/bin/Release/net10.0-ios/ios-arm64/publish/
+```
+
+### Step 6: Create App Store Connect Record
+
+1. Sign in to [App Store Connect](https://appstoreconnect.apple.com/)
+2. Click **My Apps** → **+** → **New App**
+3. Configure:
+   - Platform: **iOS**
+   - Name: **Kids ID Kit**
+   - Primary Language: **English (U.S.)**
+   - Bundle ID: Select `com.missingchildrenmn.kidsidkit`
+   - SKU: `kidsidkit-ios`
+   - User Access: **Full Access**
+4. Click **Create**
+
+### Step 7: Upload Build to App Store Connect
+
+You can upload using Xcode or Transporter:
+
+**Using Xcode:**
+1. Open Xcode
+2. Window → Organizer
+3. Select the archive
+4. Click **Distribute App**
+5. Select **App Store Connect** → **Upload**
+6. Follow prompts
+
+**Using Transporter:**
+1. Download [Transporter](https://apps.apple.com/us/app/transporter/id1450874784) from Mac App Store
+2. Export the .ipa:
+   ```bash
+   /usr/local/share/dotnet/dotnet build \
+     KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+     -t:_GenerateAppxBundle \
+     -f net10.0-ios \
+     -c Release
+   ```
+3. Open Transporter and drag the .ipa file
+
+### Step 8: Prepare App Store Listing
+
+In App Store Connect, complete the following sections:
+
+**App Information:**
+- Privacy Policy URL
+- Category: **Medical** or **Lifestyle**
+- Content Rights: As appropriate
+
+**Pricing and Availability:**
+- Price: **Free**
+- Availability: Select countries
+
+**App Privacy:**
+- Data Types Collected:
+  - Photos (for ID records)
+  - User Content (child information)
+- Data Use: Explain it's stored locally and encrypted
+
+**Version Information:**
+- Screenshots (required for 6.7", 6.5", 5.5" displays)
+  - Use iOS Simulator to capture screenshots at different sizes
+- Description:
+  ```
+  Kids ID Kit is a digital kids ID kit application for Missing Children Minnesota.
+  It allows parents to maintain a secure, encrypted digital record of their children's
+  information including photos, physical details, and emergency contacts.
+
+  Features:
+  • Secure, encrypted local storage
+  • Photo management for child ID records
+  • Physical characteristics tracking
+  • Emergency contact information
+  • Medical notes and details
+  • Social media account tracking
+  • Export capabilities for sharing with authorities if needed
+  ```
+- Keywords: `child safety, id kit, missing children, emergency contacts`
+- Support URL: https://github.com/missingchildrenmn/KidsIdKit
+- Marketing URL: https://missingchildrenmn.org (if available)
+
+**Build:**
+- Select the uploaded build
+
+**App Review Information:**
+- Contact information for app review team
+- Notes: Explain the app's purpose and test instructions
+
+### Step 9: Submit for Review
+
+1. In App Store Connect, ensure all sections have green checkmarks
+2. Click **Add for Review**
+3. Click **Submit to App Review**
+
+**Review Timeline:** Typically 1-3 days
+
+---
+
+## Troubleshooting
+
+### Build Issues
+
+**Error: "This version of .NET for iOS requires Xcode 26.2"**
+- Solution: Switch to Xcode 26.2 (see [Xcode Version Compatibility](#2-xcode-version-compatibility))
+
+**Error: "No valid iOS code signing keys found"**
+- Solution: Generate Apple Development certificate (see [Step 1: Generate Apple Development Certificate](#step-1-generate-apple-development-certificate))
+
+**Error: "Could not find any available provisioning profiles"**
+- Solution: Create provisioning profile in Xcode (see [Step 2: Create Provisioning Profile](#step-2-create-provisioning-profile))
+
+### Deployment Issues
+
+**Error: "Developer Mode is disabled"**
+- Solution: Enable Developer Mode on iPhone (see [Step 4: Enable Developer Mode](#step-4-enable-developer-mode-on-iphone))
+
+**Error: "Unable to install app"**
+- Check iPhone is unlocked
+- Trust computer on iPhone when prompted
+- Verify USB connection
+- Try: Settings → General → VPN & Device Management → Trust developer
+
+**App crashes on launch:**
+- Check Console app on Mac for crash logs
+- Common issues:
+  - Missing entitlements
+  - Privacy permissions not set in Info.plist
+  - Trimming removed required code (adjust `MtouchLink` setting)
+
+### Certificate Issues
+
+**Certificate expired:**
+- Free certificates expire after 7 days
+- Paid Apple Developer certificates expire after 1 year
+- Regenerate certificate and rebuild app
+
+**Provisioning profile expired:**
+- Regenerate in Apple Developer portal or Xcode
+- Copy new profile to `~/Library/MobileDevice/Provisioning Profiles/`
+- Rebuild app
+
+---
+
+## Quick Reference Commands
+
+```bash
+# Build for Simulator
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj -f net10.0-ios
+
+# Build for Device
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios -p:RuntimeIdentifier=ios-arm64
+
+# Deploy to Device
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj -t:Run \
+  -f net10.0-ios -p:RuntimeIdentifier=ios-arm64 \
+  -p:_DeviceName="iPhone Name"
+
+# Release Build
+/usr/local/share/dotnet/dotnet publish \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios -c Release -p:RuntimeIdentifier=ios-arm64
+
+# Clean Build
+/usr/local/share/dotnet/dotnet clean
+
+# List connected devices
+xcrun devicectl list devices
+
+# Check code signing identity
+security find-identity -v -p codesigning
+
+# List provisioning profiles
+ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
+```
+
+---
+
+## Additional Resources
+
+- [.NET MAUI Documentation](https://learn.microsoft.com/en-us/dotnet/maui/)
+- [Apple Developer Documentation](https://developer.apple.com/documentation/)
+- [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [Missing Children Minnesota](https://missingchildrenmn.org/)
+- [KidsIdKit GitHub Repository](https://github.com/missingchildrenmn/KidsIdKit)
+- [KidsIdKit Discord](https://discord.gg/ybzhYHBM2e)
+
+---
+
+## Contact
+
+For questions or issues:
+- Create an issue on [GitHub](https://github.com/missingchildrenmn/KidsIdKit/issues)
+- Join the [KidsIdKit Discord server](https://discord.gg/ybzhYHBM2e)
+
+---
+
+**Last Updated:** March 10, 2026
+**Project Version:** 1.0
+**.NET Version:** 10.0.200
+**Xcode Version:** 26.2

--- a/README_IOS.md
+++ b/README_IOS.md
@@ -281,14 +281,16 @@ You can upload using Xcode or Transporter:
 
 **Using Transporter:**
 1. Download [Transporter](https://apps.apple.com/us/app/transporter/id1450874784) from Mac App Store
-2. Export the .ipa:
+2. Build the .ipa:
    ```bash
-   /usr/local/share/dotnet/dotnet build \
+   /usr/local/share/dotnet/dotnet publish \
      KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
-     -t:_GenerateAppxBundle \
      -f net10.0-ios \
-     -c Release
+     -c Release \
+     -p:RuntimeIdentifier=ios-arm64 \
+     -p:BuildIpa=true
    ```
+   The .ipa will be created in: `KidsIdKit.Mobile/bin/Release/net10.0-ios/ios-arm64/publish/`
 3. Open Transporter and drag the .ipa file
 
 ### Step 8: Prepare App Store Listing

--- a/README_IOS.md
+++ b/README_IOS.md
@@ -24,24 +24,36 @@ This guide provides step-by-step instructions for building and deploying the Kid
    ```
 4. **.NET MAUI Workload**:
    ```bash
-   sudo /usr/local/share/dotnet/dotnet workload install maui
+   sudo dotnet workload install maui
    ```
 
 ### Verify Installation
 
 ```bash
 # Check .NET version
-/usr/local/share/dotnet/dotnet --version
+dotnet --version
 # Should show: 10.0.200 or higher
 
 # Check MAUI workload
-/usr/local/share/dotnet/dotnet workload list
+dotnet workload list
 # Should show: maui
 
 # Check Xcode version
 xcodebuild -version
 # Should show: Xcode 26.2
 ```
+
+**Note:** These commands assume `dotnet` is in your PATH. After installing via Homebrew, you may need to:
+- Restart your terminal, or
+- Add dotnet to PATH manually:
+  ```bash
+  # For Homebrew on Apple Silicon
+  export PATH="/opt/homebrew/bin:$PATH"
+
+  # For Homebrew on Intel Mac
+  export PATH="/usr/local/bin:$PATH"
+  ```
+- If `dotnet` is not found, locate it with: `which dotnet`
 
 ---
 
@@ -147,18 +159,18 @@ On iOS 16+, you must enable Developer Mode:
 cd /path/to/KidsIdKit
 
 # Build for iOS Simulator (testing without device)
-/usr/local/share/dotnet/dotnet build \
+dotnet build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios
 
 # Build for physical device
-/usr/local/share/dotnet/dotnet build \
+dotnet build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios \
   -p:RuntimeIdentifier=ios-arm64
 
 # Deploy to connected iPhone
-/usr/local/share/dotnet/dotnet build \
+dotnet build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -t:Run \
   -f net10.0-ios \
@@ -238,10 +250,10 @@ Update [KidsIdKit.Mobile.csproj](KidsIdKit.Mobile/KidsIdKit.Mobile.csproj) Relea
 
 ```bash
 # Clean previous builds
-/usr/local/share/dotnet/dotnet clean
+dotnet clean
 
 # Build Release for App Store
-/usr/local/share/dotnet/dotnet publish \
+dotnet publish \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios \
   -c Release \
@@ -283,7 +295,7 @@ You can upload using Xcode or Transporter:
 1. Download [Transporter](https://apps.apple.com/us/app/transporter/id1450874784) from Mac App Store
 2. Build the .ipa:
    ```bash
-   /usr/local/share/dotnet/dotnet publish \
+   dotnet publish \
      KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
      -f net10.0-ios \
      -c Release \
@@ -400,27 +412,27 @@ In App Store Connect, complete the following sections:
 
 ```bash
 # Build for Simulator
-/usr/local/share/dotnet/dotnet build \
+dotnet build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj -f net10.0-ios
 
 # Build for Device
-/usr/local/share/dotnet/dotnet build \
+dotnet build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios -p:RuntimeIdentifier=ios-arm64
 
 # Deploy to Device
-/usr/local/share/dotnet/dotnet build \
+dotnet build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj -t:Run \
   -f net10.0-ios -p:RuntimeIdentifier=ios-arm64 \
   -p:_DeviceName="iPhone Name"
 
 # Release Build
-/usr/local/share/dotnet/dotnet publish \
+dotnet publish \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios -c Release -p:RuntimeIdentifier=ios-arm64
 
 # Clean Build
-/usr/local/share/dotnet/dotnet clean
+dotnet clean
 
 # List connected devices
 xcrun devicectl list devices

--- a/README_IOS.md
+++ b/README_IOS.md
@@ -2,8 +2,25 @@
 
 This guide provides step-by-step instructions for building and deploying the KidsIdKit .NET MAUI Blazor app to iOS devices and the App Store.
 
+## Quick Start
+
+Already have everything set up? Jump straight to deployment:
+
+```bash
+# Deploy to your iPhone (from project root)
+./scripts/deploy-ios-device.sh "Your iPhone Name"
+
+# Or test in simulator
+./scripts/run-ios-simulator.sh
+```
+
+See [scripts/README.md](scripts/README.md) for all available commands.
+
+---
+
 ## Table of Contents
 
+- [Quick Start](#quick-start)
 - [Prerequisites](#prerequisites)
 - [Initial Setup](#initial-setup)
 - [Development Build (Testing on Your Device)](#development-build-testing-on-your-device)
@@ -154,6 +171,42 @@ On iOS 16+, you must enable Developer Mode:
 
 ### Step 5: Build and Deploy
 
+#### Option A: Using Convenience Scripts (Recommended)
+
+The project includes helper scripts in the [scripts/](scripts/) directory for common tasks:
+
+```bash
+# Check your iOS development environment setup
+./scripts/check-ios-setup.sh
+
+# Build for iOS Simulator
+./scripts/build-ios-simulator.sh
+
+# Build and run in iOS Simulator
+./scripts/run-ios-simulator.sh
+
+# Build for physical device
+./scripts/build-ios-device.sh
+
+# Deploy to connected iPhone (device name required)
+./scripts/deploy-ios-device.sh "Your iPhone Name"
+
+# List available devices to find your device name
+xcrun devicectl list devices
+
+# Clean build artifacts
+./scripts/clean-ios.sh
+```
+
+See [scripts/README.md](scripts/README.md) for detailed documentation on all available scripts.
+
+**Important Notes:**
+- Make sure your iPhone is connected via USB, unlocked, and has Developer Mode enabled
+- Free development certificates expire after 7 days. You'll need to rebuild and redeploy after this period
+- Get your exact device name from: `xcrun devicectl list devices`
+
+#### Option B: Using dotnet Commands Directly
+
 ```bash
 # Navigate to project root
 cd /path/to/KidsIdKit
@@ -177,8 +230,6 @@ dotnet build \
   -p:RuntimeIdentifier=ios-arm64 \
   -p:_DeviceName="Your iPhone Name"
 ```
-
-**Important:** Free development certificates expire after 7 days. You'll need to rebuild and redeploy after this period.
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -216,16 +216,28 @@ If you see certificate/signing errors:
 
 ## Script Maintenance
 
-These scripts use absolute paths to the .NET SDK:
+### Dotnet Resolution
+
+These scripts automatically find the `dotnet` executable using `dotnet-resolve.sh`, which checks:
+1. `$DOTNET_ROOT` environment variable (if set)
+2. `dotnet` in your `$PATH`
+3. Common installation locations:
+   - `/usr/local/share/dotnet/dotnet` (Homebrew Intel Mac)
+   - `$HOME/.dotnet/dotnet` (manual install)
+
+If dotnet is not found, the scripts will display installation instructions.
+
+**Custom dotnet location:**
+Set the `DOTNET_ROOT` environment variable:
 ```bash
-/usr/local/share/dotnet/dotnet
+export DOTNET_ROOT=/path/to/dotnet
+./scripts/build-ios-simulator.sh
 ```
 
-If your .NET installation is in a different location, update the path in each script.
-
-To find your .NET path:
+Or add to your shell profile (`~/.zshrc` or `~/.bash_profile`):
 ```bash
-which dotnet
+export DOTNET_ROOT=/path/to/dotnet
+export PATH="$DOTNET_ROOT:$PATH"
 ```
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,233 @@
+# iOS Build Scripts
+
+This directory contains helper scripts for building and deploying the KidsIdKit iOS application.
+
+## Available Scripts
+
+### Development Scripts
+
+#### `check-ios-setup.sh`
+Verifies your iOS development environment is properly configured.
+
+```bash
+./scripts/check-ios-setup.sh
+```
+
+**Checks:**
+- .NET SDK installation
+- MAUI workload installation
+- Xcode installation and version
+- Code signing certificates
+- Provisioning profiles
+- Connected iOS devices
+
+---
+
+#### `build-ios-simulator.sh`
+Builds the app for iOS Simulator (for testing without a physical device).
+
+```bash
+./scripts/build-ios-simulator.sh
+```
+
+**Output:** `KidsIdKit.Mobile/bin/Debug/net10.0-ios/iossimulator-arm64/`
+
+---
+
+#### `run-ios-simulator.sh`
+Builds and launches the app in iOS Simulator.
+
+```bash
+./scripts/run-ios-simulator.sh
+```
+
+The iOS Simulator will launch automatically and the app will install and run.
+
+---
+
+#### `build-ios-device.sh`
+Builds the app for a physical iOS device.
+
+```bash
+./scripts/build-ios-device.sh
+```
+
+**Output:** `KidsIdKit.Mobile/bin/Debug/net10.0-ios/ios-arm64/`
+
+**Requirements:**
+- Apple Development certificate installed
+- Provisioning profile for `com.missingchildrenmn.kidsidkit`
+- Device connected via USB
+
+---
+
+#### `deploy-ios-device.sh`
+Builds and deploys the app to a connected iOS device.
+
+```bash
+# Use default device name
+./scripts/deploy-ios-device.sh
+
+# Specify device name
+./scripts/deploy-ios-device.sh "My iPhone"
+```
+
+**Requirements:**
+- iOS device connected via USB
+- Device unlocked
+- Developer Mode enabled on device
+- Device trusted on Mac
+
+**Note:** Free development certificates expire after 7 days. You'll need to rebuild and redeploy.
+
+---
+
+### Release Scripts
+
+#### `build-ios-release.sh`
+Builds a Release version for App Store submission.
+
+```bash
+./scripts/build-ios-release.sh
+```
+
+**Output:** `KidsIdKit.Mobile/bin/Release/net10.0-ios/ios-arm64/publish/`
+
+**Requirements:**
+- Apple Distribution certificate installed
+- Distribution provisioning profile
+- Updated `CodesignKey` in `KidsIdKit.Mobile.csproj` Release configuration
+
+**Next Steps After Build:**
+1. Open Xcode Organizer (Window → Organizer)
+2. Or use Transporter app to upload to App Store Connect
+
+---
+
+### Utility Scripts
+
+#### `clean-ios.sh`
+Cleans all iOS build artifacts and intermediate files.
+
+```bash
+./scripts/clean-ios.sh
+```
+
+Removes:
+- `obj/` directories
+- `bin/` directories
+- Build cache
+
+Use this when you encounter build issues or want a fresh build.
+
+---
+
+## Quick Reference
+
+```bash
+# Check setup
+./scripts/check-ios-setup.sh
+
+# Test in Simulator
+./scripts/run-ios-simulator.sh
+
+# Test on Device
+./scripts/deploy-ios-device.sh "Your iPhone"
+
+# Clean build
+./scripts/clean-ios.sh
+
+# Build for App Store
+./scripts/build-ios-release.sh
+```
+
+---
+
+## Troubleshooting
+
+### Script Permission Denied
+
+If you get a permission error:
+
+```bash
+chmod +x scripts/*.sh
+```
+
+### Device Not Found
+
+If deploy script can't find your device:
+
+1. Check device is connected via USB
+2. Unlock the device
+3. Trust the computer (prompt on device)
+4. Check device name matches:
+   ```bash
+   xcrun devicectl list devices
+   ```
+
+### Build Failures
+
+1. Check your environment:
+   ```bash
+   ./scripts/check-ios-setup.sh
+   ```
+
+2. Try a clean build:
+   ```bash
+   ./scripts/clean-ios.sh
+   ./scripts/build-ios-device.sh
+   ```
+
+3. Verify Xcode version:
+   ```bash
+   xcodebuild -version
+   ```
+   Should show: Xcode 26.2
+
+### Certificate Issues
+
+If you see certificate/signing errors:
+
+1. Verify certificates exist:
+   ```bash
+   security find-identity -v -p codesigning
+   ```
+
+2. Check provisioning profiles:
+   ```bash
+   ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
+   ```
+
+3. Regenerate in Xcode:
+   - Create temp project
+   - Change Bundle ID to `com.missingchildrenmn.kidsidkit`
+   - Build to generate profile
+
+---
+
+## Additional Resources
+
+- **Full Setup Guide:** [README_IOS.md](../README_IOS.md)
+- **Project Documentation:** [readme.md](../readme.md)
+- **GitHub Issues:** https://github.com/missingchildrenmn/KidsIdKit/issues
+- **Discord:** https://discord.gg/ybzhYHBM2e
+
+---
+
+## Script Maintenance
+
+These scripts use absolute paths to the .NET SDK:
+```bash
+/usr/local/share/dotnet/dotnet
+```
+
+If your .NET installation is in a different location, update the path in each script.
+
+To find your .NET path:
+```bash
+which dotnet
+```
+
+---
+
+**Last Updated:** March 10, 2026

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,96 @@
-# iOS Build Scripts
+# Build Scripts
 
-This directory contains helper scripts for building and deploying the KidsIdKit iOS application.
+This directory contains helper scripts for building and deploying the KidsIdKit iOS and Android applications.
 
 ## Available Scripts
+
+### Android Scripts
+
+#### `check-android-setup.sh`
+Verifies your Android development environment is properly configured.
+
+```bash
+./scripts/check-android-setup.sh
+```
+
+**Checks:**
+- .NET SDK installation
+- MAUI workload installation
+- Java JDK installation
+- Android SDK installation
+- adb (Android Debug Bridge)
+- Connected Android devices
+
+---
+
+#### `build-android-device.sh`
+Builds the app for a physical Android device (arm64).
+
+```bash
+./scripts/build-android-device.sh
+```
+
+**Output:** `KidsIdKit.Mobile/bin/Debug/net10.0-android/android-arm64/`
+
+---
+
+#### `deploy-android-device.sh`
+Builds and deploys the app to a connected Android device.
+
+```bash
+./scripts/deploy-android-device.sh
+```
+
+**Requirements:**
+- Android device connected via USB
+- USB Debugging enabled on device
+- Device authorized (accepted "Allow USB Debugging" prompt)
+
+---
+
+#### `build-android-emulator.sh`
+Builds the app for Android Emulator (x64).
+
+```bash
+./scripts/build-android-emulator.sh
+```
+
+**Output:** `KidsIdKit.Mobile/bin/Debug/net10.0-android/android-x64/`
+
+---
+
+#### `run-android-emulator.sh`
+Builds and launches the app in a running Android Emulator.
+
+```bash
+./scripts/run-android-emulator.sh
+```
+
+**Requirements:** An Android Emulator must be running before executing this script.
+
+---
+
+#### `build-android-release.sh`
+Builds a signed Release AAB for Google Play Store submission.
+
+```bash
+export ANDROID_SIGNING_KEY_STORE=/path/to/kidsidkit.keystore
+export ANDROID_SIGNING_KEY_ALIAS=kidsidkit
+export ANDROID_SIGNING_KEY_PASS=your_key_password
+export ANDROID_SIGNING_STORE_PASS=your_store_password
+
+./scripts/build-android-release.sh
+```
+
+**Output:** `KidsIdKit.Mobile/bin/Release/net10.0-android/`
+
+**Requirements:**
+- Signing keystore file (generate with `keytool`)
+- Signing environment variables set
+
+---
+
+### iOS Scripts
 
 ### Development Scripts
 
@@ -124,6 +212,22 @@ Use this when you encounter build issues or want a fresh build.
 
 ## Quick Reference
 
+### Android
+```bash
+# Check setup
+./scripts/check-android-setup.sh
+
+# Test on Device
+./scripts/deploy-android-device.sh
+
+# Test in Emulator
+./scripts/run-android-emulator.sh
+
+# Build for Google Play
+./scripts/build-android-release.sh
+```
+
+### iOS
 ```bash
 # Check setup
 ./scripts/check-ios-setup.sh
@@ -207,7 +311,8 @@ If you see certificate/signing errors:
 
 ## Additional Resources
 
-- **Full Setup Guide:** [README_IOS.md](../README_IOS.md)
+- **iOS Setup Guide:** [README_IOS.md](../README_IOS.md)
+- **Android Setup Guide:** [README_ANDROID.md](../README_ANDROID.md)
 - **Project Documentation:** [readme.md](../readme.md)
 - **GitHub Issues:** https://github.com/missingchildrenmn/KidsIdKit/issues
 - **Discord:** https://discord.gg/ybzhYHBM2e

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,11 +65,11 @@ Builds the app for a physical iOS device.
 Builds and deploys the app to a connected iOS device.
 
 ```bash
-# Use default device name
-./scripts/deploy-ios-device.sh
-
-# Specify device name
+# Deploy to specified device (device name required)
 ./scripts/deploy-ios-device.sh "My iPhone"
+
+# List available devices
+xcrun devicectl list devices
 ```
 
 **Requirements:**

--- a/scripts/build-android-device.sh
+++ b/scripts/build-android-device.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Build KidsIdKit for physical Android device
+# Usage: ./scripts/build-android-device.sh
+
+set -e
+
+# Change to repo root for consistent relative paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Resolve dotnet executable
+source "$SCRIPT_DIR/dotnet-resolve.sh"
+
+echo "Building KidsIdKit for Android device..."
+
+"$DOTNET" build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-android \
+  -p:RuntimeIdentifier=android-arm64
+
+echo "✅ Build complete!"
+echo "Output: KidsIdKit.Mobile/bin/Debug/net10.0-android/android-arm64/"

--- a/scripts/build-android-emulator.sh
+++ b/scripts/build-android-emulator.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Build KidsIdKit for Android Emulator
+# Usage: ./scripts/build-android-emulator.sh
+
+set -e
+
+# Change to repo root for consistent relative paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Resolve dotnet executable
+source "$SCRIPT_DIR/dotnet-resolve.sh"
+
+echo "Building KidsIdKit for Android Emulator..."
+
+"$DOTNET" build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-android \
+  -p:RuntimeIdentifier=android-x64
+
+echo "✅ Build complete!"
+echo "Output: KidsIdKit.Mobile/bin/Debug/net10.0-android/android-x64/"

--- a/scripts/build-android-release.sh
+++ b/scripts/build-android-release.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Build KidsIdKit Release AAB for Google Play Store
+# Usage: ./scripts/build-android-release.sh
+#
+# Prerequisites:
+#   - Set ANDROID_SIGNING_KEY_STORE to path of your keystore file
+#   - Set ANDROID_SIGNING_KEY_ALIAS to your key alias
+#   - Set ANDROID_SIGNING_KEY_PASS to your key password
+#   - Set ANDROID_SIGNING_STORE_PASS to your keystore password
+#
+# Generate a keystore (one-time setup):
+#   keytool -genkeypair -v -keystore kidsidkit.keystore -alias kidsidkit \
+#     -keyalg RSA -keysize 2048 -validity 10000
+
+set -e
+
+# Change to repo root for consistent relative paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Resolve dotnet executable
+source "$SCRIPT_DIR/dotnet-resolve.sh"
+
+# Validate signing environment variables
+if [ -z "${ANDROID_SIGNING_KEY_STORE:-}" ]; then
+  echo "❌ Error: ANDROID_SIGNING_KEY_STORE is not set"
+  echo "   Export the path to your keystore file:"
+  echo "   export ANDROID_SIGNING_KEY_STORE=/path/to/kidsidkit.keystore"
+  exit 1
+fi
+
+if [ -z "${ANDROID_SIGNING_KEY_ALIAS:-}" ]; then
+  echo "❌ Error: ANDROID_SIGNING_KEY_ALIAS is not set"
+  exit 1
+fi
+
+if [ -z "${ANDROID_SIGNING_KEY_PASS:-}" ]; then
+  echo "❌ Error: ANDROID_SIGNING_KEY_PASS is not set"
+  exit 1
+fi
+
+if [ -z "${ANDROID_SIGNING_STORE_PASS:-}" ]; then
+  echo "❌ Error: ANDROID_SIGNING_STORE_PASS is not set"
+  exit 1
+fi
+
+echo "Building KidsIdKit Release AAB for Google Play..."
+
+"$DOTNET" publish \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-android \
+  -c Release \
+  -p:AndroidPackageFormat=aab \
+  -p:AndroidKeyStore=true \
+  -p:AndroidSigningKeyStore="$ANDROID_SIGNING_KEY_STORE" \
+  -p:AndroidSigningKeyAlias="$ANDROID_SIGNING_KEY_ALIAS" \
+  -p:AndroidSigningKeyPass="$ANDROID_SIGNING_KEY_PASS" \
+  -p:AndroidSigningStorePass="$ANDROID_SIGNING_STORE_PASS"
+
+echo "✅ Release AAB built!"
+echo "Output: KidsIdKit.Mobile/bin/Release/net10.0-android/"
+echo ""
+echo "Upload the .aab file to Google Play Console."

--- a/scripts/build-ios-device.sh
+++ b/scripts/build-ios-device.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Build KidsIdKit for physical iOS device
+# Usage: ./scripts/build-ios-device.sh
+
+set -e
+
+echo "Building KidsIdKit for iOS device..."
+
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios \
+  -p:RuntimeIdentifier=ios-arm64
+
+echo "✅ Build complete!"
+echo "Output: KidsIdKit.Mobile/bin/Debug/net10.0-ios/ios-arm64/"

--- a/scripts/build-ios-device.sh
+++ b/scripts/build-ios-device.sh
@@ -5,9 +5,12 @@
 
 set -e
 
+# Resolve dotnet executable
+source "$(dirname "$0")/dotnet-resolve.sh"
+
 echo "Building KidsIdKit for iOS device..."
 
-/usr/local/share/dotnet/dotnet build \
+"$DOTNET" build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios \
   -p:RuntimeIdentifier=ios-arm64

--- a/scripts/build-ios-release.sh
+++ b/scripts/build-ios-release.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Build KidsIdKit for iOS App Store Release
+# Usage: ./scripts/build-ios-release.sh
+
+set -e
+
+echo "Building KidsIdKit Release for App Store..."
+echo ""
+echo "⚠️  Make sure you have:"
+echo "  - Apple Distribution certificate installed"
+echo "  - Distribution provisioning profile installed"
+echo "  - Updated CodesignKey in KidsIdKit.Mobile.csproj"
+echo ""
+read -p "Press Enter to continue or Ctrl+C to cancel..."
+
+echo ""
+echo "Cleaning previous builds..."
+/usr/local/share/dotnet/dotnet clean KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+
+echo ""
+echo "Building Release..."
+/usr/local/share/dotnet/dotnet publish \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios \
+  -c Release \
+  -p:RuntimeIdentifier=ios-arm64 \
+  -p:ArchiveOnBuild=true
+
+echo ""
+echo "✅ Release build complete!"
+echo "Output: KidsIdKit.Mobile/bin/Release/net10.0-ios/ios-arm64/publish/"
+echo ""
+echo "Next steps:"
+echo "  1. Open Xcode Organizer (Window → Organizer)"
+echo "  2. Or use Transporter app to upload the .ipa to App Store Connect"

--- a/scripts/build-ios-release.sh
+++ b/scripts/build-ios-release.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+# Resolve dotnet executable
+source "$(dirname "$0")/dotnet-resolve.sh"
+
 echo "Building KidsIdKit Release for App Store..."
 echo ""
 echo "⚠️  Make sure you have:"
@@ -16,11 +19,11 @@ read -p "Press Enter to continue or Ctrl+C to cancel..."
 
 echo ""
 echo "Cleaning previous builds..."
-/usr/local/share/dotnet/dotnet clean KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+"$DOTNET" clean KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
 
 echo ""
 echo "Building Release..."
-/usr/local/share/dotnet/dotnet publish \
+"$DOTNET" publish \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios \
   -c Release \

--- a/scripts/build-ios-simulator.sh
+++ b/scripts/build-ios-simulator.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Build KidsIdKit for iOS Simulator
+# Usage: ./scripts/build-ios-simulator.sh
+
+set -e
+
+echo "Building KidsIdKit for iOS Simulator..."
+
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -f net10.0-ios
+
+echo "✅ Build complete!"
+echo "Output: KidsIdKit.Mobile/bin/Debug/net10.0-ios/iossimulator-arm64/"

--- a/scripts/build-ios-simulator.sh
+++ b/scripts/build-ios-simulator.sh
@@ -5,9 +5,12 @@
 
 set -e
 
+# Resolve dotnet executable
+source "$(dirname "$0")/dotnet-resolve.sh"
+
 echo "Building KidsIdKit for iOS Simulator..."
 
-/usr/local/share/dotnet/dotnet build \
+"$DOTNET" build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -f net10.0-ios
 

--- a/scripts/check-android-setup.sh
+++ b/scripts/check-android-setup.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Check Android development environment setup
+# Usage: ./scripts/check-android-setup.sh
+
+echo "Checking Android Development Environment Setup..."
+echo ""
+echo "================================================"
+
+# Resolve dotnet executable (without exiting on failure)
+if [ -n "${DOTNET_ROOT:-}" ]; then
+  DOTNET="${DOTNET_ROOT%/}/dotnet"
+elif command -v dotnet &> /dev/null; then
+  DOTNET="dotnet"
+elif [ -x "/usr/local/share/dotnet/dotnet" ]; then
+  DOTNET="/usr/local/share/dotnet/dotnet"
+elif [ -x "$HOME/.dotnet/dotnet" ]; then
+  DOTNET="$HOME/.dotnet/dotnet"
+else
+  DOTNET=""
+fi
+
+# 1. Check .NET SDK
+echo "1. Checking .NET SDK..."
+if [ -n "$DOTNET" ] && [ -x "$DOTNET" ]; then
+  VERSION=$("$DOTNET" --version)
+  echo "   ✅ .NET SDK installed: $VERSION"
+  echo "      Path: $DOTNET"
+else
+  echo "   ❌ .NET SDK not found"
+  echo "      Install: brew install --cask dotnet-sdk"
+fi
+echo ""
+
+# 2. Check MAUI workload
+echo "2. Checking MAUI workload..."
+if [ -n "$DOTNET" ] && [ -x "$DOTNET" ]; then
+  if "$DOTNET" workload list 2>/dev/null | grep -q "maui"; then
+    echo "   ✅ MAUI workload installed"
+  else
+    echo "   ❌ MAUI workload not installed"
+    echo "      Install: sudo $DOTNET workload install maui"
+  fi
+else
+  echo "   ⚠️  Cannot check (dotnet not found)"
+fi
+echo ""
+
+# 3. Check Java
+echo "3. Checking Java JDK..."
+if command -v java &> /dev/null && java -version 2>&1 | grep -q "version"; then
+  JAVA_VERSION=$(java -version 2>&1 | head -n 1)
+  echo "   ✅ Java installed: $JAVA_VERSION"
+  echo "      Path: $(which java)"
+else
+  echo "   ❌ Java not found"
+  echo "      Install: brew install --cask temurin@17"
+fi
+echo ""
+
+# 4. Check Android SDK
+echo "4. Checking Android SDK..."
+ANDROID_SDK="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+if [ -d "$ANDROID_SDK/platform-tools" ]; then
+  echo "   ✅ Android SDK found: $ANDROID_SDK"
+else
+  echo "   ❌ Android SDK not found"
+  echo "      Install: brew install --cask android-commandlinetools"
+  echo "      Then run: sdkmanager \"platform-tools\" \"platforms;android-35\" \"build-tools;35.0.0\""
+fi
+echo ""
+
+# 5. Check adb
+echo "5. Checking adb (Android Debug Bridge)..."
+if command -v adb &> /dev/null; then
+  ADB_VERSION=$(adb version | head -n 1)
+  echo "   ✅ adb installed: $ADB_VERSION"
+else
+  echo "   ❌ adb not found"
+  echo "      Ensure Android SDK platform-tools are installed and ANDROID_HOME is set"
+fi
+echo ""
+
+# 6. Check connected Android devices
+echo "6. Checking for connected Android devices..."
+if command -v adb &> /dev/null; then
+  DEVICES=$(adb devices | grep -v "List of devices" | grep "device$" || echo "")
+  if [ -n "$DEVICES" ]; then
+    echo "   ✅ Connected devices:"
+    adb devices | grep -v "List of devices" | grep -v "^$" | sed 's/^/      /'
+  else
+    echo "   ⚠️  No Android devices connected"
+    echo "      Connect device via USB with USB Debugging enabled"
+  fi
+else
+  echo "   ⚠️  Cannot check (adb not found)"
+fi
+echo ""
+
+echo "================================================"
+echo "Setup check complete!"
+echo ""
+echo "For detailed setup instructions, see: README_ANDROID.md"

--- a/scripts/check-ios-setup.sh
+++ b/scripts/check-ios-setup.sh
@@ -7,24 +7,43 @@ echo "Checking iOS Development Environment Setup..."
 echo ""
 echo "================================================"
 
+# Resolve dotnet executable (without exiting on failure)
+if [ -n "${DOTNET_ROOT:-}" ]; then
+  DOTNET="${DOTNET_ROOT%/}/dotnet"
+elif command -v dotnet &> /dev/null; then
+  DOTNET="dotnet"
+elif [ -x "/usr/local/share/dotnet/dotnet" ]; then
+  DOTNET="/usr/local/share/dotnet/dotnet"
+elif [ -x "$HOME/.dotnet/dotnet" ]; then
+  DOTNET="$HOME/.dotnet/dotnet"
+else
+  DOTNET=""
+fi
+
 # Check .NET SDK
 echo "1. Checking .NET SDK..."
-if command -v /usr/local/share/dotnet/dotnet &> /dev/null; then
-  VERSION=$(/usr/local/share/dotnet/dotnet --version)
+if [ -n "$DOTNET" ] && [ -x "$DOTNET" ]; then
+  VERSION=$("$DOTNET" --version)
   echo "   ✅ .NET SDK installed: $VERSION"
+  echo "      Path: $DOTNET"
 else
   echo "   ❌ .NET SDK not found"
   echo "      Install: brew install --cask dotnet-sdk"
+  echo "      Or visit: https://dotnet.microsoft.com/download"
 fi
 echo ""
 
 # Check MAUI workload
 echo "2. Checking MAUI workload..."
-if /usr/local/share/dotnet/dotnet workload list | grep -q "maui"; then
-  echo "   ✅ MAUI workload installed"
+if [ -n "$DOTNET" ] && [ -x "$DOTNET" ]; then
+  if "$DOTNET" workload list 2>/dev/null | grep -q "maui"; then
+    echo "   ✅ MAUI workload installed"
+  else
+    echo "   ❌ MAUI workload not installed"
+    echo "      Install: sudo $DOTNET workload install maui"
+  fi
 else
-  echo "   ❌ MAUI workload not installed"
-  echo "      Install: sudo /usr/local/share/dotnet/dotnet workload install maui"
+  echo "   ⚠️  Cannot check (dotnet not found)"
 fi
 echo ""
 

--- a/scripts/check-ios-setup.sh
+++ b/scripts/check-ios-setup.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Check iOS development environment setup
+# Usage: ./scripts/check-ios-setup.sh
+
+echo "Checking iOS Development Environment Setup..."
+echo ""
+echo "================================================"
+
+# Check .NET SDK
+echo "1. Checking .NET SDK..."
+if command -v /usr/local/share/dotnet/dotnet &> /dev/null; then
+  VERSION=$(/usr/local/share/dotnet/dotnet --version)
+  echo "   ✅ .NET SDK installed: $VERSION"
+else
+  echo "   ❌ .NET SDK not found"
+  echo "      Install: brew install --cask dotnet-sdk"
+fi
+echo ""
+
+# Check MAUI workload
+echo "2. Checking MAUI workload..."
+if /usr/local/share/dotnet/dotnet workload list | grep -q "maui"; then
+  echo "   ✅ MAUI workload installed"
+else
+  echo "   ❌ MAUI workload not installed"
+  echo "      Install: sudo /usr/local/share/dotnet/dotnet workload install maui"
+fi
+echo ""
+
+# Check Xcode
+echo "3. Checking Xcode..."
+if command -v xcodebuild &> /dev/null; then
+  XCODE_VERSION=$(xcodebuild -version | head -n 1)
+  XCODE_PATH=$(xcode-select -p)
+  echo "   ✅ Xcode installed: $XCODE_VERSION"
+  echo "      Path: $XCODE_PATH"
+else
+  echo "   ❌ Xcode not found"
+  echo "      Install from: https://developer.apple.com/download/"
+fi
+echo ""
+
+# Check code signing certificates
+echo "4. Checking code signing certificates..."
+CERT_COUNT=$(security find-identity -v -p codesigning 2>/dev/null | grep -c "Apple Development\|Apple Distribution")
+if [ "$CERT_COUNT" -gt 0 ]; then
+  echo "   ✅ Found $CERT_COUNT code signing certificate(s):"
+  security find-identity -v -p codesigning 2>/dev/null | grep "Apple Development\|Apple Distribution" | sed 's/^/      /'
+else
+  echo "   ⚠️  No code signing certificates found"
+  echo "      Generate in Xcode: Create temp project and enable signing"
+fi
+echo ""
+
+# Check provisioning profiles
+echo "5. Checking provisioning profiles..."
+PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+if [ -d "$PROFILE_DIR" ]; then
+  PROFILE_COUNT=$(ls -1 "$PROFILE_DIR"/*.mobileprovision 2>/dev/null | wc -l)
+  if [ "$PROFILE_COUNT" -gt 0 ]; then
+    echo "   ✅ Found $PROFILE_COUNT provisioning profile(s)"
+  else
+    echo "   ⚠️  No provisioning profiles found"
+    echo "      Generate in Xcode with matching Bundle ID"
+  fi
+else
+  echo "   ⚠️  Provisioning profiles directory not found"
+fi
+echo ""
+
+# Check for connected devices
+echo "6. Checking for connected iOS devices..."
+if command -v xcrun &> /dev/null; then
+  DEVICES=$(xcrun devicectl list devices 2>/dev/null | grep -i "iPhone\|iPad" || echo "")
+  if [ -n "$DEVICES" ]; then
+    echo "   ✅ Connected devices:"
+    echo "$DEVICES" | sed 's/^/      /'
+  else
+    echo "   ⚠️  No iOS devices connected"
+    echo "      Connect device via USB for testing"
+  fi
+else
+  echo "   ❌ xcrun not available"
+fi
+echo ""
+
+echo "================================================"
+echo "Setup check complete!"
+echo ""
+echo "For detailed setup instructions, see: README_IOS.md"

--- a/scripts/clean-ios.sh
+++ b/scripts/clean-ios.sh
@@ -5,9 +5,12 @@
 
 set -e
 
+# Resolve dotnet executable
+source "$(dirname "$0")/dotnet-resolve.sh"
+
 echo "Cleaning iOS build artifacts..."
 
-/usr/local/share/dotnet/dotnet clean KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+"$DOTNET" clean KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
 
 # Remove obj and bin directories
 rm -rf KidsIdKit.Mobile/obj

--- a/scripts/clean-ios.sh
+++ b/scripts/clean-ios.sh
@@ -5,8 +5,12 @@
 
 set -e
 
+# Change to repo root (parent of scripts directory)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
 # Resolve dotnet executable
-source "$(dirname "$0")/dotnet-resolve.sh"
+source "$SCRIPT_DIR/dotnet-resolve.sh"
 
 echo "Cleaning iOS build artifacts..."
 

--- a/scripts/clean-ios.sh
+++ b/scripts/clean-ios.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Clean iOS build artifacts
+# Usage: ./scripts/clean-ios.sh
+
+set -e
+
+echo "Cleaning iOS build artifacts..."
+
+/usr/local/share/dotnet/dotnet clean KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+
+# Remove obj and bin directories
+rm -rf KidsIdKit.Mobile/obj
+rm -rf KidsIdKit.Mobile/bin
+rm -rf KidsIdKit.Core/obj
+rm -rf KidsIdKit.Core/bin
+
+echo "✅ Clean complete!"

--- a/scripts/deploy-android-device.sh
+++ b/scripts/deploy-android-device.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Build and deploy KidsIdKit to a connected Android device
+# Usage: ./scripts/deploy-android-device.sh
+
+set -e
+
+# Change to repo root for consistent relative paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Resolve dotnet executable
+source "$SCRIPT_DIR/dotnet-resolve.sh"
+
+echo "Deploying KidsIdKit to Android device..."
+echo "Make sure your device is:"
+echo "  - Connected via USB"
+echo "  - Unlocked"
+echo "  - Has USB Debugging enabled (Settings → Developer Options)"
+echo ""
+
+# Check for connected devices
+echo "Checking for connected devices..."
+if ! command -v adb &> /dev/null; then
+  echo "❌ Error: adb not found. Ensure Android SDK platform-tools are installed."
+  echo "   Set ANDROID_HOME or add platform-tools to PATH."
+  exit 1
+fi
+
+DEVICES=$(adb devices | grep -v "List of devices" | grep "device$")
+if [ -z "$DEVICES" ]; then
+  echo "❌ No Android devices connected."
+  echo "   Connect your device via USB with USB Debugging enabled."
+  exit 1
+fi
+
+echo "Found device(s):"
+adb devices | grep -v "List of devices" | grep -v "^$" | sed 's/^/  /'
+echo ""
+
+echo "Building and deploying..."
+"$DOTNET" build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -t:Run \
+  -f net10.0-android
+
+echo "✅ Deployment complete!"

--- a/scripts/deploy-ios-device.sh
+++ b/scripts/deploy-ios-device.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Deploy KidsIdKit to connected iOS device
+# Usage: ./scripts/deploy-ios-device.sh [device-name]
+# Example: ./scripts/deploy-ios-device.sh "Perry iPhone"
+
+set -e
+
+# Get device name from argument or use default
+DEVICE_NAME="${1:-Perry iPhone}"
+
+echo "Deploying KidsIdKit to device: $DEVICE_NAME"
+echo "Make sure your device is:"
+echo "  - Connected via USB"
+echo "  - Unlocked"
+echo "  - Has Developer Mode enabled"
+echo ""
+
+# Check if device is connected
+echo "Checking for connected devices..."
+xcrun devicectl list devices | grep -i "iPhone\|iPad" || {
+  echo "❌ No iOS devices found. Please connect your device."
+  exit 1
+}
+
+echo ""
+echo "Building and deploying..."
+
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -t:Run \
+  -f net10.0-ios \
+  -p:RuntimeIdentifier=ios-arm64 \
+  -p:_DeviceName="$DEVICE_NAME"
+
+echo ""
+echo "✅ Deployment complete!"
+echo "The app should now be running on your device."

--- a/scripts/deploy-ios-device.sh
+++ b/scripts/deploy-ios-device.sh
@@ -9,8 +9,17 @@ set -e
 # Resolve dotnet executable
 source "$(dirname "$0")/dotnet-resolve.sh"
 
-# Get device name from argument or use default
-DEVICE_NAME="${1:-Perry iPhone}"
+# Get device name from argument (required)
+if [ -z "$1" ]; then
+  echo "❌ Error: Device name required"
+  echo "Usage: $0 \"Device Name\""
+  echo ""
+  echo "Available devices:"
+  xcrun devicectl list devices 2>/dev/null | grep -i "iPhone\|iPad" || echo "  No devices found"
+  exit 1
+fi
+
+DEVICE_NAME="$1"
 
 echo "Deploying KidsIdKit to device: $DEVICE_NAME"
 echo "Make sure your device is:"

--- a/scripts/deploy-ios-device.sh
+++ b/scripts/deploy-ios-device.sh
@@ -6,6 +6,9 @@
 
 set -e
 
+# Resolve dotnet executable
+source "$(dirname "$0")/dotnet-resolve.sh"
+
 # Get device name from argument or use default
 DEVICE_NAME="${1:-Perry iPhone}"
 
@@ -26,7 +29,7 @@ xcrun devicectl list devices | grep -i "iPhone\|iPad" || {
 echo ""
 echo "Building and deploying..."
 
-/usr/local/share/dotnet/dotnet build \
+"$DOTNET" build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -t:Run \
   -f net10.0-ios \

--- a/scripts/dotnet-resolve.sh
+++ b/scripts/dotnet-resolve.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Shared dotnet resolution logic for all scripts
+# Source this file at the start of each script: source "$(dirname "$0")/dotnet-resolve.sh"
+
+# Resolve dotnet from DOTNET_ROOT or PATH for portability
+if [ -n "${DOTNET_ROOT:-}" ]; then
+  DOTNET="${DOTNET_ROOT%/}/dotnet"
+elif command -v dotnet &> /dev/null; then
+  DOTNET="dotnet"
+else
+  # Common installation locations
+  if [ -x "/usr/local/share/dotnet/dotnet" ]; then
+    DOTNET="/usr/local/share/dotnet/dotnet"
+  elif [ -x "$HOME/.dotnet/dotnet" ]; then
+    DOTNET="$HOME/.dotnet/dotnet"
+  else
+    echo "❌ Error: Could not find 'dotnet' executable." >&2
+    echo "   Please ensure .NET SDK is installed and either:" >&2
+    echo "   - Add dotnet to your PATH, or" >&2
+    echo "   - Set DOTNET_ROOT environment variable" >&2
+    echo "" >&2
+    echo "   Install .NET SDK: https://dotnet.microsoft.com/download" >&2
+    exit 1
+  fi
+fi
+
+# Verify dotnet is executable
+if [ ! -x "$DOTNET" ]; then
+  echo "❌ Error: Found dotnet at '$DOTNET' but it's not executable." >&2
+  exit 1
+fi
+
+# Export for use in scripts
+export DOTNET

--- a/scripts/run-android-emulator.sh
+++ b/scripts/run-android-emulator.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Build and run KidsIdKit in Android Emulator
+# Usage: ./scripts/run-android-emulator.sh
+
+set -e
+
+# Change to repo root for consistent relative paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Resolve dotnet executable
+source "$SCRIPT_DIR/dotnet-resolve.sh"
+
+echo "Building and running KidsIdKit in Android Emulator..."
+echo "Make sure an Android Emulator is running."
+echo ""
+
+"$DOTNET" build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -t:Run \
+  -f net10.0-android \
+  -p:RuntimeIdentifier=android-x64
+
+echo "✅ App launched in emulator!"

--- a/scripts/run-ios-simulator.sh
+++ b/scripts/run-ios-simulator.sh
@@ -5,9 +5,12 @@
 
 set -e
 
+# Resolve dotnet executable
+source "$(dirname "$0")/dotnet-resolve.sh"
+
 echo "Building and running KidsIdKit in iOS Simulator..."
 
-/usr/local/share/dotnet/dotnet build \
+"$DOTNET" build \
   KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
   -t:Run \
   -f net10.0-ios

--- a/scripts/run-ios-simulator.sh
+++ b/scripts/run-ios-simulator.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Build and run KidsIdKit in iOS Simulator
+# Usage: ./scripts/run-ios-simulator.sh
+
+set -e
+
+echo "Building and running KidsIdKit in iOS Simulator..."
+
+/usr/local/share/dotnet/dotnet build \
+  KidsIdKit.Mobile/KidsIdKit.Mobile.csproj \
+  -t:Run \
+  -f net10.0-ios
+
+echo ""
+echo "✅ App should now be running in the iOS Simulator!"


### PR DESCRIPTION
## Summary

- Adds full Android build and deployment support for the KidsIdKit .NET MAUI Blazor app
- Upgrades `KidsIdKit.Web`, `KidsIdKit.Tests`, and `KidsIdKit.Core` to .NET 10.0 (fixes CI build failure where projects targeted mismatched framework versions)
- Bumps MacCatalyst minimum version from 14.0 to 15.0 to meet SDK requirements
- Builds on iOS work from PR #132

**Android-specific changes:**
- `AndroidManifest.xml` — added camera and storage permissions required for photo features
- `README_ANDROID.md` — full Android deployment guide (prerequisites, device setup, Google Play submission)
- `scripts/build-android-device.sh` — build for physical Android device
- `scripts/build-android-emulator.sh` — build for Android Emulator
- `scripts/run-android-emulator.sh` — build and run in emulator
- `scripts/deploy-android-device.sh` — build and deploy to connected device via adb
- `scripts/build-android-release.sh` — build release AAB for Google Play
- `scripts/check-android-setup.sh` — verify Android development environment
- `scripts/README.md` — updated with Android scripts documentation

## Test plan

- [ ] Install prerequisites: Java JDK 17 (`brew install --cask temurin@17`), Android command-line tools (`brew install --cask android-commandlinetools`)
- [ ] Set environment variables: `JAVA_HOME`, `ANDROID_HOME` in `~/.zshrc`
- [ ] Install Android SDK components: `sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"`
- [ ] Enable USB Debugging on Android device (Settings → Developer Options)
- [ ] Run `./scripts/check-android-setup.sh` to verify environment
- [ ] Run `./scripts/deploy-android-device.sh` with device connected via USB
- [ ] Verify app installs and launches on Android device
- [ ] Run `dotnet test KidsIdKit.Tests/KidsIdKit.Tests.csproj` — all 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)