### PR TITLE
Adjust ion-input min-height and padding in overrides

### DIFF
--- a/KidsIdKit.Core/wwwroot/css/ionic-overrides.css
+++ b/KidsIdKit.Core/wwwroot/css/ionic-overrides.css
@@ -6,3 +6,9 @@
     --ion-color-secondary-shade: #084150;
     --ion-color-secondary-tint: #437985;
 }
+
+ion-input {
+    min-height: 34px !important;
+    --padding-top: 4px;
+    --padding-bottom: 4px;
+}


### PR DESCRIPTION
Added custom styles to ion-input in ionic-overrides.css, setting a minimum height of 34px and updating top and bottom padding to 4px for improved input appearance.

@rockfordlhotka Note: Once we finalize color issues, we can then decide what to do with [PR # 157](https://github.com/missingchildrenmn/KidsIdKit/pull/157).