### PR TITLE
Fix for crash on startup due to LLVM compiler being enabled without turning off AndroidEnableProfiledAot

### DIFF
--- a/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+++ b/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
@@ -54,7 +54,8 @@
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
-		<EnableLLVM>True</EnableLLVM>
+        <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+        <EnableLLVM>true</EnableLLVM>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
 

--- a/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+++ b/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
@@ -54,8 +54,8 @@
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
 		<ApplicationId>com.missingchildrenmn.kidsidkit</ApplicationId>
-        <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
-        <EnableLLVM>true</EnableLLVM>
+		<AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+		<EnableLLVM>True</EnableLLVM>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/114794