### PR TITLE
168 - Implement unsaved changes alerts for Child Detail, Child Physical Details, and Child Medical Notes pages

### DIFF
--- a/KidsIdKit.Core/Data/Person.cs
+++ b/KidsIdKit.Core/Data/Person.cs
@@ -12,7 +12,8 @@ namespace KidsIdKit.Core.Data
 
         [Display(Name = "Nickname")]
         public string? NickName { get; set; }
-       
+
+        [Required]
         [Display(Name = "Family name")]
         public string? FamilyName { get; set; }
        

--- a/KidsIdKit.Core/Pages/CareProviders/ChildCareProviderDetails.razor
+++ b/KidsIdKit.Core/Pages/CareProviders/ChildCareProviderDetails.razor
@@ -7,14 +7,14 @@
 @inject IFamilyStateService FamilyState
 @inject NavigationManager NavigationManager
 
-@inherits PageBase
+@inherits EditablePageBase<Data.CareProvider>
 
 @{
 base.BuildRenderTree(__builder);
 }
 
 <ion-content class="ion-padding">
-@if (CurrentChild == null || CareProvider == null)
+@if (CurrentChild == null || EditingObject == null)
 {
     <ion-spinner></ion-spinner>
     <p>Loading...</p>
@@ -24,24 +24,29 @@ else
     <ion-text><h2>@CurrentChild.FullName</h2></ion-text>
     <ion-text><h3>@PageTitle</h3></ion-text>
 
-    <EditForm Model="CareProvider" OnSubmit="SaveData">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
-        <ion-grid>
-            <EditTextRow @bind-Value="CareProvider.ClinicName" />
-            <EditTextRow @bind-Value="CareProvider.Address" />
-            <EditTextRow @bind-Value="CareProvider.PhoneNumber" />
-            <EditTextRow @bind-Value="CareProvider.CareRoleDescription" />
-            <EditTextRow @bind-Value="CareProvider.GivenName" />
-            <EditTextRow @bind-Value="CareProvider.NickName" />
-            <EditTextRow @bind-Value="CareProvider.FamilyName" />
-        </ion-grid>
-        <div class="ion-padding">
-            <ion-button expand="block" type="submit" color="secondary">
-                <ion-icon slot="start" name="save"></ion-icon>
-                Save
-            </ion-button>
-        </div>
+    <EditForm Model="EditingObject" OnSubmit="SaveData" Context="editFormContext">
+        <CascadingValue Value="this">
+            @{
+                SetEditContext(editFormContext);
+            }
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <ion-grid>
+                <EditTextRow @bind-Value="EditingObject!.ClinicName" />
+                <EditTextRow @bind-Value="EditingObject!.Address" />
+                <EditTextRow @bind-Value="EditingObject!.PhoneNumber" />
+                <EditTextRow @bind-Value="EditingObject!.CareRoleDescription" />
+                <EditTextRow @bind-Value="EditingObject!.GivenName" />
+                <EditTextRow @bind-Value="EditingObject!.NickName" />
+                <EditTextRow @bind-Value="EditingObject!.FamilyName" />
+            </ion-grid>
+            <div class="ion-padding">
+                <ion-button expand="block" type="submit" color="secondary">
+                    <ion-icon slot="start" name="save"></ion-icon>
+                    Save
+                </ion-button>
+            </div>
+        </CascadingValue>
     </EditForm>
 }
 </ion-content>

--- a/KidsIdKit.Core/Pages/CareProviders/ChildCareProviderDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/CareProviders/ChildCareProviderDetails.razor.cs
@@ -32,11 +32,22 @@ public partial class ChildCareProviderDetails : EditablePageBase<Data.CareProvid
                 EditingObject = new CareProvider();
                 EditingObject!.Id = child.ProfessionalCareProviders.Count == 0 ? 0 : child.ProfessionalCareProviders.Max(r => r.Id) + 1;
             }
-            else if (CareId >= 0 && CareId < child.ProfessionalCareProviders.Count)
+            else
             {
-                EditingObject = child.ProfessionalCareProviders[CareId];
+                var index = child.ProfessionalCareProviders.FindIndex(p => p.Id == CareId);
+                if (index >= 0)
+                {
+                    EditingObject = child.ProfessionalCareProviders[index];
+                }
+                else
+                {
+                    Console.WriteLine($"Care provider with an ID of {CareId} was not found");
+                }
             }
-            originalSnapshot = SerializeObject(EditingObject!);
+            if (EditingObject != null)
+            { 
+                originalSnapshot = SerializeObject(EditingObject!);
+            }
         }
     }
 
@@ -51,7 +62,14 @@ public partial class ChildCareProviderDetails : EditablePageBase<Data.CareProvid
         if (child.ProfessionalCareProviders.Any(f => f.Id == CareId))
         {
             var index = child.ProfessionalCareProviders.FindIndex(f => f.Id == unalteredObject.Id);
-            child.ProfessionalCareProviders[index] = unalteredObject;
+            if (index >= 0)
+            {
+                child.ProfessionalCareProviders[index] = unalteredObject;
+            }
+            else
+            {
+                Console.WriteLine($"Care provider with an ID of {CareId} was not found");
+            }
         }
         return unalteredObject;
     }

--- a/KidsIdKit.Core/Pages/CareProviders/ChildCareProviderDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/CareProviders/ChildCareProviderDetails.razor.cs
@@ -1,4 +1,5 @@
 ﻿using KidsIdKit.Core.Data;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
@@ -6,57 +7,76 @@ using System.Text;
 
 namespace KidsIdKit.Core.Pages.CareProviders;
 
-public partial class ChildCareProviderDetails
+public partial class ChildCareProviderDetails : EditablePageBase<Data.CareProvider>
 {
     [Parameter]
-    public int childId { get; set; }
+    public int ChildId { get; set; }
 
     [Parameter]
-    public int careId { get; set; }
+    public int CareId { get; set; }
 
     ChildDetails? CurrentChild;
-    CareProvider? CareProvider;
 
     readonly string PageTitle = "Care Provider";
     public override string MenuBarTitle { get; protected set; } = "Care Provider";
     protected override void OnInitialized()
     {
 
-        var child = FamilyState.GetChild(childId);
+        var child = FamilyState.GetChild(ChildId);
         if (child != null)
         {
             CurrentChild = child.ChildDetails;
 
-            if (careId == -1)
+            if (CareId == -1)
             {
-                CareProvider = new CareProvider();
-                CareProvider.Id = child.ProfessionalCareProviders.Count == 0 ? 0 : child.ProfessionalCareProviders.Max(r => r.Id) + 1;
+                EditingObject = new CareProvider();
+                EditingObject!.Id = child.ProfessionalCareProviders.Count == 0 ? 0 : child.ProfessionalCareProviders.Max(r => r.Id) + 1;
             }
-            else if (careId >= 0 && careId < child.ProfessionalCareProviders.Count)
+            else if (CareId >= 0 && CareId < child.ProfessionalCareProviders.Count)
             {
-                CareProvider = child.ProfessionalCareProviders[careId];
+                EditingObject = child.ProfessionalCareProviders[CareId];
             }
+            originalSnapshot = SerializeObject(EditingObject!);
         }
     }
 
-    private async Task SaveData()
+    protected override CareProvider ResetUnalteredObject(CareProvider unalteredObject)
     {
-        try
+        var child = FamilyState.GetChild(ChildId);
+        if (child == null)
         {
-            var child = FamilyState.GetChild(childId);
-            if (child != null && CareProvider is not null)
-            {
-                if (careId == -1)
-                {
-                    child.ProfessionalCareProviders.Add(CareProvider);
-                }
-                await FamilyState.SaveAsync();
-            }
-            await NavigateBack();
+            return unalteredObject;
         }
-        catch (Exception e)
+
+        if (child.ProfessionalCareProviders.Any(f => f.Id == CareId))
         {
-            Console.WriteLine(e.ToString());
+            var index = child.ProfessionalCareProviders.FindIndex(f => f.Id == unalteredObject.Id);
+            child.ProfessionalCareProviders[index] = unalteredObject;
+        }
+        return unalteredObject;
+    }
+
+    protected override async Task SaveData()
+    {
+        if (ValidateChangesForSave())
+        {
+            try
+            {
+                var child = FamilyState.GetChild(ChildId);
+                if (child != null && EditingObject is not null)
+                {
+                    if (CareId == -1)
+                    {
+                        child.ProfessionalCareProviders.Add(EditingObject);
+                    }
+                    await FamilyState.SaveAsync();
+                }
+                await NavigateBack();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
         }
     }
 }

--- a/KidsIdKit.Core/Pages/Child/ChildDetails.razor
+++ b/KidsIdKit.Core/Pages/Child/ChildDetails.razor
@@ -12,6 +12,13 @@
 base.BuildRenderTree(__builder);
 }
 
+<McmAlert Header="Unsaved changes"
+          Message="Do you want to save your pending changes or discard them?"
+          ConfirmPrompt="Save"
+          CancelPrompt="Discard"
+          Show="ShowPendingChangesAlert"
+          AlertClosed="OnPendingChangesAlertClosed" />
+
 <ion-content class="ion-padding">
     @if (!string.IsNullOrWhiteSpace(messageText))
     {
@@ -39,78 +46,83 @@ base.BuildRenderTree(__builder);
 
         bool photoExists = !string.IsNullOrWhiteSpace(CurrentChild.Photo.ImageSource);
 
-        <EditForm Model="CurrentChild" OnValidSubmit="SaveData">
-            <DataAnnotationsValidator />
-            <ValidationSummary />
-
-            <ion-grid>
-                <EditTextRow @bind-Value="CurrentChild.GivenName" />
-                <EditTextRow @bind-Value="CurrentChild.NickName" />
-                <EditTextRow @bind-Value="CurrentChild.AdditionalName" />
-                <EditTextRow @bind-Value="CurrentChild.MiddleName" />
-                <EditTextRow @bind-Value="CurrentChild.FamilyName" />
-                <EditDateRow @bind-Value="CurrentChild.Birthday" />
-                <EditTextRow @bind-Value="CurrentChild.PhoneNumber" />
-            </ion-grid>
-
-            <ion-list>
-                <ion-list-header>
-                    <ion-label>Photo</ion-label>
-                </ion-list-header>
-                <ion-item>
-                    <ion-label>
-                        @if (SelectingImage)
-                        {
-                            <p>Selecting photo...</p>
-                        }
-                        else
-                        {
-                            <p>@(photoExists ? "Photo selected" : "No photo selected")</p>
-                        }
-                    </ion-label>
-                </ion-item>
-                <ion-item>
-                    <div class="ion-margin">
-                        @if (!SelectingImage)
-                        {
-                            <ion-button expand="block" fill="outline" @onclick="() => SelectingImage = true">
-                                <ion-icon slot="start" name="@(photoExists ? "create" : "add-circle")"></ion-icon>
-                                @(photoExists ? "Change" : "Add") photo
-                            </ion-button>
-                        }
-                    </div>
-                </ion-item>
-                @if (SelectingImage)
-                {
-                    <ion-item>
-                        <PhotoPicker Complete="(selectedPhoto) =>   {
-                                                                        CurrentChild.Photo = selectedPhoto;
-                                                                        SelectingImage = false;
-                                                                    }"
-                                     Cancel="() => SelectingImage = false" />
-                    </ion-item>
+        <EditForm Model="CurrentChild" OnValidSubmit="SaveData" Context="editFormContext">
+            <CascadingValue Value="this">
+                @{
+                    SetEditContext(editFormContext);
                 }
-                else if (photoExists)
-                {
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+
+                <ion-grid>
+                    <EditTextRow @bind-Value="CurrentChild.GivenName" />
+                    <EditTextRow @bind-Value="CurrentChild.NickName" />
+                    <EditTextRow @bind-Value="CurrentChild.AdditionalName" />
+                    <EditTextRow @bind-Value="CurrentChild.MiddleName" />
+                    <EditTextRow @bind-Value="CurrentChild.FamilyName" />
+                    <EditDateRow @bind-Value="CurrentChild.Birthday" />
+                    <EditTextRow @bind-Value="CurrentChild.PhoneNumber" />
+                </ion-grid>
+
+                <ion-list>
+                    <ion-list-header>
+                        <ion-label>Photo</ion-label>
+                    </ion-list-header>
+                    <ion-item>
+                        <ion-label>
+                            @if (SelectingImage)
+                            {
+                                <p>Selecting photo...</p>
+                            }
+                            else
+                            {
+                                <p>@(photoExists ? "Photo selected" : "No photo selected")</p>
+                            }
+                        </ion-label>
+                    </ion-item>
                     <ion-item>
                         <div class="ion-margin">
-                            <ion-img src="@CurrentChild.Photo.ImageSource" 
-                                    alt="Photo of child"
-                                    style="max-width: 100%; height: auto; border-radius: 8px;"></ion-img>
+                            @if (!SelectingImage)
+                            {
+                                <ion-button expand="block" fill="outline" @onclick="() => SelectingImage = true">
+                                    <ion-icon slot="start" name="@(photoExists ? "create" : "add-circle")"></ion-icon>
+                                    @(photoExists ? "Change" : "Add") photo
+                                </ion-button>
+                            }
                         </div>
                     </ion-item>
-                }
-            </ion-list>
+                    @if (SelectingImage)
+                    {
+                        <ion-item>
+                            <PhotoPicker Complete="(selectedPhoto) =>   {
+                                                                            CurrentChild.Photo = selectedPhoto;
+                                                                            SelectingImage = false;
+                                                                        }"
+                                         Cancel="() => SelectingImage = false" />
+                        </ion-item>
+                    }
+                    else if (photoExists)
+                    {
+                        <ion-item>
+                            <div class="ion-margin">
+                                <ion-img src="@CurrentChild.Photo.ImageSource" 
+                                        alt="Photo of child"
+                                        style="max-width: 100%; height: auto; border-radius: 8px;"></ion-img>
+                            </div>
+                        </ion-item>
+                    }
+                </ion-list>
 
-            <div class="ion-padding">
-                @if (!SelectingImage)
-                {
-                    <ion-button expand="block" type="submit" color="secondary">
-                        <ion-icon slot="start" name="save"></ion-icon>
-                        Save
-                    </ion-button>
-                }
-            </div>
+                <div class="ion-padding">
+                    @if (!SelectingImage)
+                    {
+                        <ion-button expand="block" type="submit" color="secondary">
+                            <ion-icon slot="start" name="save"></ion-icon>
+                            Save
+                        </ion-button>
+                    }
+                </div>
+            </CascadingValue>
         </EditForm>
     }
 </ion-content>

--- a/KidsIdKit.Core/Pages/Child/ChildDetails.razor
+++ b/KidsIdKit.Core/Pages/Child/ChildDetails.razor
@@ -6,18 +6,11 @@
 
 @inject IDataAccess dal
 
-@inherits DetailsPage
+@inherits DetailsPage<Data.ChildDetails>
 
 @{
 base.BuildRenderTree(__builder);
 }
-
-<McmAlert Header="Unsaved changes"
-          Message="Do you want to save your pending changes or discard them?"
-          ConfirmPrompt="Save"
-          CancelPrompt="Discard"
-          Show="ShowPendingChangesAlert"
-          AlertClosed="OnPendingChangesAlertClosed" />
 
 <ion-content class="ion-padding">
     @if (!string.IsNullOrWhiteSpace(messageText))
@@ -31,7 +24,7 @@ base.BuildRenderTree(__builder);
         </ion-card>
     }
 
-    @if (CurrentChild == null)
+    @if (EditingObject == null)
     {
         <ion-spinner></ion-spinner>
         <p>Loading...</p>
@@ -40,13 +33,13 @@ base.BuildRenderTree(__builder);
     {
         <ion-card>
             <ion-card-header>
-                <ion-card-title>@CurrentChild.FullName</ion-card-title>
+                <ion-card-title>@EditingObject.FullName</ion-card-title>
             </ion-card-header>
         </ion-card>
 
-        bool photoExists = !string.IsNullOrWhiteSpace(CurrentChild.Photo.ImageSource);
+        bool photoExists = !string.IsNullOrWhiteSpace(EditingObject.Photo.ImageSource);
 
-        <EditForm Model="CurrentChild" OnValidSubmit="SaveData" Context="editFormContext">
+        <EditForm Model="EditingObject" OnSubmit="SaveData" Context="editFormContext">
             <CascadingValue Value="this">
                 @{
                     SetEditContext(editFormContext);
@@ -55,13 +48,13 @@ base.BuildRenderTree(__builder);
                 <ValidationSummary />
 
                 <ion-grid>
-                    <EditTextRow @bind-Value="CurrentChild.GivenName" />
-                    <EditTextRow @bind-Value="CurrentChild.NickName" />
-                    <EditTextRow @bind-Value="CurrentChild.AdditionalName" />
-                    <EditTextRow @bind-Value="CurrentChild.MiddleName" />
-                    <EditTextRow @bind-Value="CurrentChild.FamilyName" />
-                    <EditDateRow @bind-Value="CurrentChild.Birthday" />
-                    <EditTextRow @bind-Value="CurrentChild.PhoneNumber" />
+                    <EditTextRow @bind-Value="EditingObject!.GivenName" />
+                    <EditTextRow @bind-Value="EditingObject!.NickName" />
+                    <EditTextRow @bind-Value="EditingObject!.AdditionalName" />
+                    <EditTextRow @bind-Value="EditingObject!.MiddleName" />
+                    <EditTextRow @bind-Value="EditingObject!.FamilyName" />
+                    <EditDateRow @bind-Value="EditingObject!.Birthday" />
+                    <EditTextRow @bind-Value="EditingObject!.PhoneNumber" />
                 </ion-grid>
 
                 <ion-list>
@@ -95,7 +88,7 @@ base.BuildRenderTree(__builder);
                     {
                         <ion-item>
                             <PhotoPicker Complete="(selectedPhoto) =>   {
-                                                                            CurrentChild.Photo = selectedPhoto;
+                                                                            EditingObject!.Photo = selectedPhoto;
                                                                             SelectingImage = false;
                                                                         }"
                                          Cancel="() => SelectingImage = false" />
@@ -105,7 +98,7 @@ base.BuildRenderTree(__builder);
                     {
                         <ion-item>
                             <div class="ion-margin">
-                                <ion-img src="@CurrentChild.Photo.ImageSource" 
+                                <ion-img src="@EditingObject!.Photo.ImageSource" 
                                         alt="Photo of child"
                                         style="max-width: 100%; height: auto; border-radius: 8px;"></ion-img>
                             </div>

--- a/KidsIdKit.Core/Pages/Child/ChildDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildDetails.razor.cs
@@ -36,42 +36,6 @@ public partial class ChildDetails: DetailsPage<Data.ChildDetails>
         }
     }
 
-    private void RestoreOriginalChildDetails()
-    {
-        if (string.IsNullOrWhiteSpace(originalSnapshot))
-        {
-            return;
-        }
-
-        var originalChildDetails = JsonSerializer.Deserialize<Data.ChildDetails>(originalSnapshot);
-        if (originalChildDetails == null)
-        {
-            return;
-        }
-
-        var child = FamilyState.GetChild(Id);
-        if (child == null)
-        {
-            EditingObject = originalChildDetails;
-        }
-        else
-        {
-            child.ChildDetails = originalChildDetails;
-            EditingObject = child.ChildDetails;
-
-            // If this is a newly created child (empty GivenName) and it's still in the collection,
-            // remove it since the user is discarding changes without entering a name
-            if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
-            {
-                FamilyState.Family.Children.Remove(child);
-            }
-        }
-
-        originalSnapshot = SerializeObject(EditingObject);
-        MenuBarTitle = GetMenuBarTitle();
-        SelectingImage = false;
-    }
-
     protected override void RemoveAnyEmptyObjects()
     {
         if (EditingObject == null || !string.IsNullOrWhiteSpace(EditingObject!.GivenName) || FamilyState.Family == null)

--- a/KidsIdKit.Core/Pages/Child/ChildDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildDetails.razor.cs
@@ -1,34 +1,28 @@
 using System.Text.Json;
 using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 
 namespace KidsIdKit.Core.Pages.Child;
 
-public partial class ChildDetails
+public partial class ChildDetails: DetailsPage<Data.ChildDetails>
 {
     [Parameter] public int Id { get; set; }
-
-    private Data.ChildDetails? CurrentChild { get; set; }
-    private EditContext? EditContext { get; set; }
 
     public override string MenuBarTitle { get; protected set; } = string.Empty;
 
     private readonly string PageTitle = "Child Details";
     private bool SelectingImage;
-    private bool ShowPendingChangesAlert;
-    private string? originalChildSnapshot;
     private int? snapshotChildId;
 
     protected override void OnParametersSet()
     {
         var child = FamilyState.GetChild(Id);
-        CurrentChild = child?.ChildDetails;
+        EditingObject = child?.ChildDetails;
         MenuBarTitle = GetMenuBarTitle();
 
-        if (CurrentChild == null)
+        if (EditingObject == null)
         {
-            originalChildSnapshot = null;
+            originalSnapshot = null;
             snapshotChildId = null;
             ShowPendingChangesAlert = false;
             return;
@@ -36,62 +30,20 @@ public partial class ChildDetails
 
         if (snapshotChildId != Id)
         {
-            originalChildSnapshot = SerializeChildDetails(CurrentChild);
+            originalSnapshot = SerializeObject(EditingObject);
             snapshotChildId = Id;
             ShowPendingChangesAlert = false;
         }
     }
 
-    protected override async Task OnBackButtonClicked()
-    {
-        if (!HasPendingChanges())
-        {
-            RemoveEmptyNewChild();
-            await NavigateBack();
-            return;
-        }
-
-        ShowPendingChangesAlert = true;
-    }
-
-    private async Task SaveData() => await InternalSaveData();
-
-    private async Task OnPendingChangesAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
-    {
-        ShowPendingChangesAlert = false;
-
-        if (result.action == McmAlert.AlertAction.Confirm)
-        {
-            // Validate before saving
-            if (EditContext != null && EditContext.Validate())
-            {
-                await SaveData();
-            }
-            else
-            {
-                // Validation failed, show the alert again
-                ShowPendingChangesAlert = true;
-            }
-            return;
-        }
-
-        RestoreOriginalChildDetails();
-        await NavigateBack();
-    }
-
-    private bool HasPendingChanges() =>
-        CurrentChild != null &&
-        !string.IsNullOrWhiteSpace(originalChildSnapshot) &&
-        SerializeChildDetails(CurrentChild) != originalChildSnapshot;
-
     private void RestoreOriginalChildDetails()
     {
-        if (string.IsNullOrWhiteSpace(originalChildSnapshot))
+        if (string.IsNullOrWhiteSpace(originalSnapshot))
         {
             return;
         }
 
-        var originalChildDetails = JsonSerializer.Deserialize<Data.ChildDetails>(originalChildSnapshot);
+        var originalChildDetails = JsonSerializer.Deserialize<Data.ChildDetails>(originalSnapshot);
         if (originalChildDetails == null)
         {
             return;
@@ -100,12 +52,12 @@ public partial class ChildDetails
         var child = FamilyState.GetChild(Id);
         if (child == null)
         {
-            CurrentChild = originalChildDetails;
+            EditingObject = originalChildDetails;
         }
         else
         {
             child.ChildDetails = originalChildDetails;
-            CurrentChild = child.ChildDetails;
+            EditingObject = child.ChildDetails;
 
             // If this is a newly created child (empty GivenName) and it's still in the collection,
             // remove it since the user is discarding changes without entering a name
@@ -115,14 +67,14 @@ public partial class ChildDetails
             }
         }
 
-        originalChildSnapshot = SerializeChildDetails(CurrentChild);
+        originalSnapshot = SerializeObject(EditingObject);
         MenuBarTitle = GetMenuBarTitle();
         SelectingImage = false;
     }
 
-    private void RemoveEmptyNewChild()
+    protected override void RemoveAnyEmptyObjects()
     {
-        if (CurrentChild == null || !string.IsNullOrWhiteSpace(CurrentChild.GivenName) || FamilyState.Family == null)
+        if (EditingObject == null || !string.IsNullOrWhiteSpace(EditingObject!.GivenName) || FamilyState.Family == null)
         {
             return;
         }
@@ -134,13 +86,36 @@ public partial class ChildDetails
         }
     }
 
-    public void SetEditContext(EditContext context)
+    private string GetMenuBarTitle() =>
+        EditingObject == null ? PageTitle : string.IsNullOrWhiteSpace(EditingObject!.GivenName) ? "New Child" : PageTitle;
+
+    protected override Data.ChildDetails ResetUnalteredObject(Data.ChildDetails unalteredObject)
     {
-        EditContext = context;
+        var child = FamilyState.GetChild(Id);
+        if (child == null)
+        {
+            return unalteredObject;
+        }
+        else
+        {
+            child.ChildDetails = unalteredObject;
+
+            // If this is a newly created child (empty GivenName) and it's still in the collection,
+            // remove it since the user is discarding changes without entering a name
+            if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+            {
+                FamilyState.Family.Children.Remove(child);
+            }
+
+            return child.ChildDetails;
+        }
     }
 
-    private string GetMenuBarTitle() =>
-        CurrentChild == null ? PageTitle : string.IsNullOrWhiteSpace(CurrentChild.GivenName) ? "New Child" : PageTitle;
-
-    private static string SerializeChildDetails(Data.ChildDetails childDetails) => JsonSerializer.Serialize(childDetails);
+    protected override async Task SaveData()
+    {
+        if (ValidateChangesForSave())
+        {
+            await InternalSaveData();
+        }
+    }
 }

--- a/KidsIdKit.Core/Pages/Child/ChildDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildDetails.razor.cs
@@ -1,4 +1,7 @@
+using System.Text.Json;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 
 namespace KidsIdKit.Core.Pages.Child;
 
@@ -6,19 +9,138 @@ public partial class ChildDetails
 {
     [Parameter] public int Id { get; set; }
 
-    Data.ChildDetails? CurrentChild { get; set; }
+    private Data.ChildDetails? CurrentChild { get; set; }
+    private EditContext? EditContext { get; set; }
 
     public override string MenuBarTitle { get; protected set; } = string.Empty;
 
-    readonly string PageTitle = "Child Details";
+    private readonly string PageTitle = "Child Details";
     private bool SelectingImage;
+    private bool ShowPendingChangesAlert;
+    private string? originalChildSnapshot;
+    private int? snapshotChildId;
 
     protected override void OnParametersSet()
     {
         var child = FamilyState.GetChild(Id);
         CurrentChild = child?.ChildDetails;
-        MenuBarTitle = CurrentChild == null ? PageTitle : string.IsNullOrWhiteSpace(CurrentChild.GivenName) ? "New Child" : PageTitle;
+        MenuBarTitle = GetMenuBarTitle();
+
+        if (CurrentChild == null)
+        {
+            originalChildSnapshot = null;
+            snapshotChildId = null;
+            ShowPendingChangesAlert = false;
+            return;
+        }
+
+        if (snapshotChildId != Id)
+        {
+            originalChildSnapshot = SerializeChildDetails(CurrentChild);
+            snapshotChildId = Id;
+            ShowPendingChangesAlert = false;
+        }
+    }
+
+    protected override async Task OnBackButtonClicked()
+    {
+        if (!HasPendingChanges())
+        {
+            RemoveEmptyNewChild();
+            await NavigateBack();
+            return;
+        }
+
+        ShowPendingChangesAlert = true;
     }
 
     private async Task SaveData() => await InternalSaveData();
+
+    private async Task OnPendingChangesAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
+    {
+        ShowPendingChangesAlert = false;
+
+        if (result.action == McmAlert.AlertAction.Confirm)
+        {
+            // Validate before saving
+            if (EditContext != null && EditContext.Validate())
+            {
+                await SaveData();
+            }
+            else
+            {
+                // Validation failed, show the alert again
+                ShowPendingChangesAlert = true;
+            }
+            return;
+        }
+
+        RestoreOriginalChildDetails();
+        await NavigateBack();
+    }
+
+    private bool HasPendingChanges() =>
+        CurrentChild != null &&
+        !string.IsNullOrWhiteSpace(originalChildSnapshot) &&
+        SerializeChildDetails(CurrentChild) != originalChildSnapshot;
+
+    private void RestoreOriginalChildDetails()
+    {
+        if (string.IsNullOrWhiteSpace(originalChildSnapshot))
+        {
+            return;
+        }
+
+        var originalChildDetails = JsonSerializer.Deserialize<Data.ChildDetails>(originalChildSnapshot);
+        if (originalChildDetails == null)
+        {
+            return;
+        }
+
+        var child = FamilyState.GetChild(Id);
+        if (child == null)
+        {
+            CurrentChild = originalChildDetails;
+        }
+        else
+        {
+            child.ChildDetails = originalChildDetails;
+            CurrentChild = child.ChildDetails;
+
+            // If this is a newly created child (empty GivenName) and it's still in the collection,
+            // remove it since the user is discarding changes without entering a name
+            if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+            {
+                FamilyState.Family.Children.Remove(child);
+            }
+        }
+
+        originalChildSnapshot = SerializeChildDetails(CurrentChild);
+        MenuBarTitle = GetMenuBarTitle();
+        SelectingImage = false;
+    }
+
+    private void RemoveEmptyNewChild()
+    {
+        if (CurrentChild == null || !string.IsNullOrWhiteSpace(CurrentChild.GivenName) || FamilyState.Family == null)
+        {
+            return;
+        }
+
+        var child = FamilyState.GetChild(Id);
+        if (child != null && string.IsNullOrWhiteSpace(child.ChildDetails.GivenName))
+        {
+            FamilyState.Family.Children.Remove(child);
+        }
+    }
+
+    public void SetEditContext(EditContext context)
+    {
+        EditContext = context;
+    }
+
+    private string GetMenuBarTitle() =>
+        CurrentChild == null ? PageTitle : string.IsNullOrWhiteSpace(CurrentChild.GivenName) ? "New Child" : PageTitle;
+
+    private static string SerializeChildDetails(Data.ChildDetails childDetails) => JsonSerializer.Serialize(childDetails);
 }

--- a/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor
+++ b/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor
@@ -1,6 +1,6 @@
 @page "/childMedicalNotes/{id:int}"
 
-@inherits DetailsPage
+@inherits DetailsPage<Data.MedicalNotes>
 
 @using System.Linq.Expressions;
 @using System.ComponentModel.DataAnnotations;
@@ -12,16 +12,9 @@
     base.BuildRenderTree(__builder);
 }
 
-<McmAlert Header="Unsaved changes"
-          Message="Do you want to save your pending changes or discard them?"
-          ConfirmPrompt="Save"
-          CancelPrompt="Discard"
-          Show="ShowPendingChangesAlert"
-          AlertClosed="OnPendingChangesAlertClosed" />
-
 <ion-content class="ion-padding">
 
-@if (CurrentChild == null || MedicalNotes == null)
+@if (CurrentChild == null || EditingObject == null)
 {
     <ion-spinner></ion-spinner>
     <p>Loading...</p>
@@ -34,7 +27,7 @@ else
         </ion-card-header>
     </ion-card>
 
-    <EditForm Model="MedicalNotes" OnValidSubmit="SaveData" Context="editFormContext">
+    <EditForm Model="EditingObject" OnSubmit="SaveData" Context="editFormContext">
         <CascadingValue Value="this">
             @{
                 SetEditContext(editFormContext);
@@ -42,13 +35,13 @@ else
             <DataAnnotationsValidator />
             <ValidationSummary />
             <ion-grid>
-                <EditTextRow @bind-Value="MedicalNotes.MedicAlertInfo" />
-                <EditTextRow @bind-Value="MedicalNotes.Allergies" />
-                <EditTextRow @bind-Value="MedicalNotes.RegularMedications" />
-                <EditTextRow @bind-Value="MedicalNotes.PsychMedications" />
-                <EditTextRow @bind-Value="MedicalNotes.Notes" />
-                <EditBoolRow @bind-Value="MedicalNotes.Inhaler" />
-                <EditBoolRow @bind-Value="MedicalNotes.Diabetic" />
+                <EditTextRow @bind-Value="EditingObject!.MedicAlertInfo" />
+                <EditTextRow @bind-Value="EditingObject!.Allergies" />
+                <EditTextRow @bind-Value="EditingObject!.RegularMedications" />
+                <EditTextRow @bind-Value="EditingObject!.PsychMedications" />
+                <EditTextRow @bind-Value="EditingObject!.Notes" />
+                <EditBoolRow @bind-Value="EditingObject!.Inhaler" />
+                <EditBoolRow @bind-Value="EditingObject!.Diabetic" />
             </ion-grid>
 
             <div class="ion-padding">

--- a/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor
+++ b/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor
@@ -12,6 +12,13 @@
     base.BuildRenderTree(__builder);
 }
 
+<McmAlert Header="Unsaved changes"
+          Message="Do you want to save your pending changes or discard them?"
+          ConfirmPrompt="Save"
+          CancelPrompt="Discard"
+          Show="ShowPendingChangesAlert"
+          AlertClosed="OnPendingChangesAlertClosed" />
+
 <ion-content class="ion-padding">
 
 @if (CurrentChild == null || MedicalNotes == null)
@@ -27,25 +34,30 @@ else
         </ion-card-header>
     </ion-card>
 
-    <EditForm Model="MedicalNotes" OnSubmit="SaveData">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
-        <ion-grid>
-            <EditTextRow @bind-Value="MedicalNotes.MedicAlertInfo" />
-            <EditTextRow @bind-Value="MedicalNotes.Allergies" />
-            <EditTextRow @bind-Value="MedicalNotes.RegularMedications" />
-            <EditTextRow @bind-Value="MedicalNotes.PsychMedications" />
-            <EditTextRow @bind-Value="MedicalNotes.Notes" />
-            <EditBoolRow @bind-Value="MedicalNotes.Inhaler" />
-            <EditBoolRow @bind-Value="MedicalNotes.Diabetic" />
-        </ion-grid>
+    <EditForm Model="MedicalNotes" OnValidSubmit="SaveData" Context="editFormContext">
+        <CascadingValue Value="this">
+            @{
+                SetEditContext(editFormContext);
+            }
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <ion-grid>
+                <EditTextRow @bind-Value="MedicalNotes.MedicAlertInfo" />
+                <EditTextRow @bind-Value="MedicalNotes.Allergies" />
+                <EditTextRow @bind-Value="MedicalNotes.RegularMedications" />
+                <EditTextRow @bind-Value="MedicalNotes.PsychMedications" />
+                <EditTextRow @bind-Value="MedicalNotes.Notes" />
+                <EditBoolRow @bind-Value="MedicalNotes.Inhaler" />
+                <EditBoolRow @bind-Value="MedicalNotes.Diabetic" />
+            </ion-grid>
 
-        <div class="ion-padding">
-            <ion-button expand="block" type="submit" color="secondary">
-                <ion-icon slot="start" name="save"></ion-icon>
-                Save
-            </ion-button>
-        </div>
+            <div class="ion-padding">
+                <ion-button expand="block" type="submit" color="secondary">
+                    <ion-icon slot="start" name="save"></ion-icon>
+                    Save
+                </ion-button>
+            </div>
+        </CascadingValue>
     </EditForm>
 }
 </ion-content>

--- a/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor.cs
@@ -1,4 +1,7 @@
+using System.Text.Json;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 
 namespace KidsIdKit.Core.Pages.Child;
 
@@ -8,18 +11,125 @@ public partial class ChildMedicalNotes
     public int Id { get; set; }
     public override string MenuBarTitle { get; protected set; } = "Medical Notes";
 
-    Data.ChildDetails? CurrentChild;
-    Data.MedicalNotes? MedicalNotes;
+    private Data.ChildDetails? CurrentChild;
+    private Data.MedicalNotes? MedicalNotes;
+    private EditContext? EditContext;
+    private bool ShowPendingChangesAlert;
+    private string? originalMedicalNotesSnapshot;
+    private int? snapshotChildId;
 
     protected override void OnParametersSet()
     {
         var child = FamilyState.GetChild(Id);
-        if (child != null)
+        if (child == null)
         {
-            CurrentChild = child.ChildDetails;
-            MedicalNotes = child.MedicalNotes;
+            CurrentChild = null;
+            MedicalNotes = null;
+            originalMedicalNotesSnapshot = null;
+            snapshotChildId = null;
+            ShowPendingChangesAlert = false;
+            return;
+        }
+
+        CurrentChild = child.ChildDetails;
+        MedicalNotes = child.MedicalNotes;
+
+        if (snapshotChildId != Id && MedicalNotes != null)
+        {
+            originalMedicalNotesSnapshot = SerializeMedicalNotes(MedicalNotes);
+            snapshotChildId = Id;
+            ShowPendingChangesAlert = false;
         }
     }
 
+    protected override async Task OnBackButtonClicked()
+    {
+        if (!HasPendingChanges())
+        {
+            RemoveEmptyNewChild();
+            await NavigateBack();
+            return;
+        }
+
+        ShowPendingChangesAlert = true;
+    }
+
     private async Task SaveData() => await InternalSaveData();
+
+    private async Task OnPendingChangesAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
+    {
+        ShowPendingChangesAlert = false;
+
+        if (result.action == McmAlert.AlertAction.Confirm)
+        {
+            // Validate before saving
+            if (EditContext != null && EditContext.Validate())
+            {
+                await SaveData();
+            }
+            else
+            {
+                // Validation failed, show the alert again
+                ShowPendingChangesAlert = true;
+            }
+            return;
+        }
+
+        RestoreOriginalMedicalNotes();
+        await NavigateBack();
+    }
+
+    private bool HasPendingChanges() =>
+        MedicalNotes != null &&
+        !string.IsNullOrWhiteSpace(originalMedicalNotesSnapshot) &&
+        SerializeMedicalNotes(MedicalNotes) != originalMedicalNotesSnapshot;
+
+    private void RestoreOriginalMedicalNotes()
+    {
+        if (string.IsNullOrWhiteSpace(originalMedicalNotesSnapshot))
+        {
+            return;
+        }
+
+        var originalMedicalNotes = JsonSerializer.Deserialize<Data.MedicalNotes>(originalMedicalNotesSnapshot);
+        if (originalMedicalNotes == null)
+        {
+            return;
+        }
+
+        var child = FamilyState.GetChild(Id);
+        if (child == null)
+        {
+            MedicalNotes = originalMedicalNotes;
+            return;
+        }
+
+        child.MedicalNotes = originalMedicalNotes;
+        MedicalNotes = child.MedicalNotes;
+
+        // If this is a newly created child (empty GivenName) and it's still in the collection,
+        // remove it since the user is discarding changes without entering a name
+        if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+        {
+            FamilyState.Family.Children.Remove(child);
+        }
+
+        originalMedicalNotesSnapshot = SerializeMedicalNotes(MedicalNotes);
+    }
+
+    private void RemoveEmptyNewChild()
+    {
+        var child = FamilyState.GetChild(Id);
+        if (child != null && string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+        {
+            FamilyState.Family.Children.Remove(child);
+        }
+    }
+
+    public void SetEditContext(EditContext context)
+    {
+        EditContext = context;
+    }
+
+    private static string SerializeMedicalNotes(Data.MedicalNotes medicalNotes) => JsonSerializer.Serialize(medicalNotes);
 }

--- a/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor.cs
@@ -40,38 +40,6 @@ public partial class ChildMedicalNotes : DetailsPage<Data.MedicalNotes>
         }
     }
 
-    private void RestoreOriginalMedicalNotes()
-    {
-        if (string.IsNullOrWhiteSpace(originalSnapshot))
-        {
-            return;
-        }
-
-        var originalMedicalNotes = JsonSerializer.Deserialize<Data.MedicalNotes>(originalSnapshot);
-        if (originalMedicalNotes == null)
-        {
-            return;
-        }
-
-        var child = FamilyState.GetChild(Id);
-        if (child == null)
-        {
-            EditingObject = originalMedicalNotes;
-            return;
-        }
-
-        
-    }
-
-    private void RemoveEmptyNewChild()
-    {
-        var child = FamilyState.GetChild(Id);
-        if (child != null && string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
-        {
-            FamilyState.Family.Children.Remove(child);
-        }
-    }
-
     protected override MedicalNotes ResetUnalteredObject(MedicalNotes unalteredObject)
     {
         var child = FamilyState.GetChild(Id);

--- a/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildMedicalNotes.razor.cs
@@ -1,21 +1,19 @@
 using System.Text.Json;
+using KidsIdKit.Core.Data;
 using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace KidsIdKit.Core.Pages.Child;
 
-public partial class ChildMedicalNotes
+public partial class ChildMedicalNotes : DetailsPage<Data.MedicalNotes>
 {
     [Parameter]
     public int Id { get; set; }
     public override string MenuBarTitle { get; protected set; } = "Medical Notes";
 
     private Data.ChildDetails? CurrentChild;
-    private Data.MedicalNotes? MedicalNotes;
-    private EditContext? EditContext;
-    private bool ShowPendingChangesAlert;
-    private string? originalMedicalNotesSnapshot;
+
     private int? snapshotChildId;
 
     protected override void OnParametersSet()
@@ -24,74 +22,32 @@ public partial class ChildMedicalNotes
         if (child == null)
         {
             CurrentChild = null;
-            MedicalNotes = null;
-            originalMedicalNotesSnapshot = null;
+            EditingObject = null;
+            originalSnapshot = null;
             snapshotChildId = null;
             ShowPendingChangesAlert = false;
             return;
         }
 
         CurrentChild = child.ChildDetails;
-        MedicalNotes = child.MedicalNotes;
+        EditingObject = child.MedicalNotes;
 
-        if (snapshotChildId != Id && MedicalNotes != null)
+        if (snapshotChildId != Id && EditingObject != null)
         {
-            originalMedicalNotesSnapshot = SerializeMedicalNotes(MedicalNotes);
+            originalSnapshot = SerializeObject(EditingObject);
             snapshotChildId = Id;
             ShowPendingChangesAlert = false;
         }
     }
 
-    protected override async Task OnBackButtonClicked()
-    {
-        if (!HasPendingChanges())
-        {
-            RemoveEmptyNewChild();
-            await NavigateBack();
-            return;
-        }
-
-        ShowPendingChangesAlert = true;
-    }
-
-    private async Task SaveData() => await InternalSaveData();
-
-    private async Task OnPendingChangesAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
-    {
-        ShowPendingChangesAlert = false;
-
-        if (result.action == McmAlert.AlertAction.Confirm)
-        {
-            // Validate before saving
-            if (EditContext != null && EditContext.Validate())
-            {
-                await SaveData();
-            }
-            else
-            {
-                // Validation failed, show the alert again
-                ShowPendingChangesAlert = true;
-            }
-            return;
-        }
-
-        RestoreOriginalMedicalNotes();
-        await NavigateBack();
-    }
-
-    private bool HasPendingChanges() =>
-        MedicalNotes != null &&
-        !string.IsNullOrWhiteSpace(originalMedicalNotesSnapshot) &&
-        SerializeMedicalNotes(MedicalNotes) != originalMedicalNotesSnapshot;
-
     private void RestoreOriginalMedicalNotes()
     {
-        if (string.IsNullOrWhiteSpace(originalMedicalNotesSnapshot))
+        if (string.IsNullOrWhiteSpace(originalSnapshot))
         {
             return;
         }
 
-        var originalMedicalNotes = JsonSerializer.Deserialize<Data.MedicalNotes>(originalMedicalNotesSnapshot);
+        var originalMedicalNotes = JsonSerializer.Deserialize<Data.MedicalNotes>(originalSnapshot);
         if (originalMedicalNotes == null)
         {
             return;
@@ -100,21 +56,11 @@ public partial class ChildMedicalNotes
         var child = FamilyState.GetChild(Id);
         if (child == null)
         {
-            MedicalNotes = originalMedicalNotes;
+            EditingObject = originalMedicalNotes;
             return;
         }
 
-        child.MedicalNotes = originalMedicalNotes;
-        MedicalNotes = child.MedicalNotes;
-
-        // If this is a newly created child (empty GivenName) and it's still in the collection,
-        // remove it since the user is discarding changes without entering a name
-        if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
-        {
-            FamilyState.Family.Children.Remove(child);
-        }
-
-        originalMedicalNotesSnapshot = SerializeMedicalNotes(MedicalNotes);
+        
     }
 
     private void RemoveEmptyNewChild()
@@ -126,10 +72,31 @@ public partial class ChildMedicalNotes
         }
     }
 
-    public void SetEditContext(EditContext context)
+    protected override MedicalNotes ResetUnalteredObject(MedicalNotes unalteredObject)
     {
-        EditContext = context;
+        var child = FamilyState.GetChild(Id);
+        if (child == null)
+        {
+            return unalteredObject;
+        }
+
+        child.MedicalNotes = unalteredObject;
+
+        // If this is a newly created child (empty GivenName) and it's still in the collection,
+        // remove it since the user is discarding changes without entering a name
+        if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+        {
+            FamilyState.Family.Children.Remove(child);
+        }
+
+        return child.MedicalNotes;
     }
 
-    private static string SerializeMedicalNotes(Data.MedicalNotes medicalNotes) => JsonSerializer.Serialize(medicalNotes);
+    protected override async Task SaveData()
+    {
+        if (ValidateChangesForSave())
+        {
+            await InternalSaveData();
+        }
+    }
 }

--- a/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor
+++ b/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor
@@ -1,6 +1,6 @@
 @page "/childPhysicalDetails/{id:int}"
 
-@inherits DetailsPage
+@inherits DetailsPage<Data.PhysicalDetails>
 
 @using System.Linq.Expressions;
 @using System.ComponentModel.DataAnnotations;
@@ -10,16 +10,10 @@
 @{
     base.BuildRenderTree(__builder);
 }
-<McmAlert Header="Unsaved changes"
-          Message="Do you want to save your pending changes or discard them?"
-          ConfirmPrompt="Save"
-          CancelPrompt="Discard"
-          Show="ShowPendingChangesAlert"
-          AlertClosed="OnPendingChangesAlertClosed" />
 <ion-content class="ion-padding">
     <div class="alert-danger">@messageText</div>
 
-@if (CurrentChild == null || Details == null)
+@if (CurrentChild == null || EditingObject == null)
 {
     <ion-spinner></ion-spinner>
     <p>Loading...</p>
@@ -32,7 +26,7 @@ else
         </ion-card-header>
     </ion-card>
 
-    <EditForm Model="Details" OnValidSubmit="SaveData" Context="editFormContext">
+    <EditForm Model="EditingObject" OnSubmit="SaveData" Context="editFormContext">
         <CascadingValue Value="this">
             @{
                 SetEditContext(editFormContext);
@@ -40,17 +34,17 @@ else
             <DataAnnotationsValidator />
             <ValidationSummary />
             <ion-grid>
-                <EditDateRow @bind-Value="Details.MeasurementDate" />
-                <EditTextRow @bind-Value="Details.Height" />
-                <EditTextRow @bind-Value="Details.HairColor" />
-                <EditTextRow @bind-Value="Details.HairStyle" />
-                <EditTextRow @bind-Value="Details.EyeColor" />
-                <EditBoolRow @bind-Value="Details.EyeContacts" />
-                <EditBoolRow @bind-Value="Details.EyeGlasses" />
-                <EditTextRow @bind-Value="Details.SkinTone" />
-                <EditTextRow @bind-Value="Details.RacialEthnicIdentity" />
-                <EditTextRow @bind-Value="Details.Sex" />
-                <EditTextRow @bind-Value="Details.GenderIdentity" />
+                <EditDateRow @bind-Value="EditingObject!.MeasurementDate" />
+                <EditTextRow @bind-Value="EditingObject!.Height" />
+                <EditTextRow @bind-Value="EditingObject!.HairColor" />
+                <EditTextRow @bind-Value="EditingObject!.HairStyle" />
+                <EditTextRow @bind-Value="EditingObject!.EyeColor" />
+                <EditBoolRow @bind-Value="EditingObject!.EyeContacts" />
+                <EditBoolRow @bind-Value="EditingObject!.EyeGlasses" />
+                <EditTextRow @bind-Value="EditingObject!.SkinTone" />
+                <EditTextRow @bind-Value="EditingObject!.RacialEthnicIdentity" />
+                <EditTextRow @bind-Value="EditingObject!.Sex" />
+                <EditTextRow @bind-Value="EditingObject!.GenderIdentity" />
             </ion-grid>
 
             <div class="ion-padding">

--- a/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor
+++ b/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor
@@ -10,6 +10,12 @@
 @{
     base.BuildRenderTree(__builder);
 }
+<McmAlert Header="Unsaved changes"
+          Message="Do you want to save your pending changes or discard them?"
+          ConfirmPrompt="Save"
+          CancelPrompt="Discard"
+          Show="ShowPendingChangesAlert"
+          AlertClosed="OnPendingChangesAlertClosed" />
 <ion-content class="ion-padding">
     <div class="alert-danger">@messageText</div>
 
@@ -26,29 +32,34 @@ else
         </ion-card-header>
     </ion-card>
 
-    <EditForm Model="Details" OnSubmit="SaveData">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
-        <ion-grid>
-            <EditDateRow @bind-Value="Details.MeasurementDate" />
-            <EditTextRow @bind-Value="Details.Height" />
-            <EditTextRow @bind-Value="Details.HairColor" />
-            <EditTextRow @bind-Value="Details.HairStyle" />
-            <EditTextRow @bind-Value="Details.EyeColor" />
-            <EditBoolRow @bind-Value="Details.EyeContacts" />
-            <EditBoolRow @bind-Value="Details.EyeGlasses" />
-            <EditTextRow @bind-Value="Details.SkinTone" />
-            <EditTextRow @bind-Value="Details.RacialEthnicIdentity" />
-            <EditTextRow @bind-Value="Details.Sex" />
-            <EditTextRow @bind-Value="Details.GenderIdentity" />
-        </ion-grid>
+    <EditForm Model="Details" OnValidSubmit="SaveData" Context="editFormContext">
+        <CascadingValue Value="this">
+            @{
+                SetEditContext(editFormContext);
+            }
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <ion-grid>
+                <EditDateRow @bind-Value="Details.MeasurementDate" />
+                <EditTextRow @bind-Value="Details.Height" />
+                <EditTextRow @bind-Value="Details.HairColor" />
+                <EditTextRow @bind-Value="Details.HairStyle" />
+                <EditTextRow @bind-Value="Details.EyeColor" />
+                <EditBoolRow @bind-Value="Details.EyeContacts" />
+                <EditBoolRow @bind-Value="Details.EyeGlasses" />
+                <EditTextRow @bind-Value="Details.SkinTone" />
+                <EditTextRow @bind-Value="Details.RacialEthnicIdentity" />
+                <EditTextRow @bind-Value="Details.Sex" />
+                <EditTextRow @bind-Value="Details.GenderIdentity" />
+            </ion-grid>
 
-        <div class="ion-padding">
-            <ion-button expand="block" type="submit" color="secondary">
-                <ion-icon slot="start" name="save"></ion-icon>
-                Save
-            </ion-button>
-        </div>
+            <div class="ion-padding">
+                <ion-button expand="block" type="submit" color="secondary">
+                    <ion-icon slot="start" name="save"></ion-icon>
+                    Save
+                </ion-button>
+            </div>
+        </CascadingValue>
     </EditForm>
 }
 </ion-content>

--- a/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor.cs
@@ -40,15 +40,6 @@ public partial class ChildPhysicalDetails : DetailsPage<Data.PhysicalDetails>
         }
     }
 
-    protected override void RemoveAnyEmptyObjects()
-    {
-        var child = FamilyState.GetChild(Id);
-        if (child != null && string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
-        {
-            FamilyState.Family.Children.Remove(child);
-        }
-    }
-
     protected override PhysicalDetails ResetUnalteredObject(PhysicalDetails unalteredObject)
     {
         var child = FamilyState.GetChild(Id);

--- a/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor.cs
@@ -1,4 +1,7 @@
+using System.Text.Json;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 
 namespace KidsIdKit.Core.Pages.Child;
 
@@ -8,18 +11,125 @@ public partial class ChildPhysicalDetails
     public int Id { get; set; }
     public override string MenuBarTitle { get; protected set; } = "Physical Details";
 
-    Data.ChildDetails? CurrentChild;
-    Data.PhysicalDetails? Details;
+    private Data.ChildDetails? CurrentChild;
+    private Data.PhysicalDetails? Details;
+    private EditContext? EditContext;
+    private bool ShowPendingChangesAlert;
+    private string? originalPhysicalDetailsSnapshot;
+    private int? snapshotChildId;
 
     protected override void OnParametersSet()
     {
         var child = FamilyState.GetChild(Id);
-        if (child != null)
+        if (child == null)
         {
-            CurrentChild = child.ChildDetails;
-            Details = child.PhysicalDetails;
+            CurrentChild = null;
+            Details = null;
+            originalPhysicalDetailsSnapshot = null;
+            snapshotChildId = null;
+            ShowPendingChangesAlert = false;
+            return;
+        }
+
+        CurrentChild = child.ChildDetails;
+        Details = child.PhysicalDetails;
+
+        if (snapshotChildId != Id && Details != null)
+        {
+            originalPhysicalDetailsSnapshot = SerializePhysicalDetails(Details);
+            snapshotChildId = Id;
+            ShowPendingChangesAlert = false;
         }
     }
 
+    protected override async Task OnBackButtonClicked()
+    {
+        if (!HasPendingChanges())
+        {
+            RemoveEmptyNewChild();
+            await NavigateBack();
+            return;
+        }
+
+        ShowPendingChangesAlert = true;
+    }
+
     private async Task SaveData() => await InternalSaveData();
+
+    private async Task OnPendingChangesAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
+    {
+        ShowPendingChangesAlert = false;
+
+        if (result.action == McmAlert.AlertAction.Confirm)
+        {
+            // Validate before saving
+            if (EditContext != null && EditContext.Validate())
+            {
+                await SaveData();
+            }
+            else
+            {
+                // Validation failed, show the alert again
+                ShowPendingChangesAlert = true;
+            }
+            return;
+        }
+
+        RestoreOriginalPhysicalDetails();
+        await NavigateBack();
+    }
+
+    private bool HasPendingChanges() =>
+        Details != null &&
+        !string.IsNullOrWhiteSpace(originalPhysicalDetailsSnapshot) &&
+        SerializePhysicalDetails(Details) != originalPhysicalDetailsSnapshot;
+
+    private void RestoreOriginalPhysicalDetails()
+    {
+        if (string.IsNullOrWhiteSpace(originalPhysicalDetailsSnapshot))
+        {
+            return;
+        }
+
+        var originalPhysicalDetails = JsonSerializer.Deserialize<Data.PhysicalDetails>(originalPhysicalDetailsSnapshot);
+        if (originalPhysicalDetails == null)
+        {
+            return;
+        }
+
+        var child = FamilyState.GetChild(Id);
+        if (child == null)
+        {
+            Details = originalPhysicalDetails;
+            return;
+        }
+
+        child.PhysicalDetails = originalPhysicalDetails;
+        Details = child.PhysicalDetails;
+
+        // If this is a newly created child (empty GivenName) and it's still in the collection,
+        // remove it since the user is discarding changes without entering a name
+        if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+        {
+            FamilyState.Family.Children.Remove(child);
+        }
+
+        originalPhysicalDetailsSnapshot = SerializePhysicalDetails(Details);
+    }
+
+    private void RemoveEmptyNewChild()
+    {
+        var child = FamilyState.GetChild(Id);
+        if (child != null && string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+        {
+            FamilyState.Family.Children.Remove(child);
+        }
+    }
+
+    public void SetEditContext(EditContext context)
+    {
+        EditContext = context;
+    }
+
+    private static string SerializePhysicalDetails(Data.PhysicalDetails physicalDetails) => JsonSerializer.Serialize(physicalDetails);
 }

--- a/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Child/ChildPhysicalDetails.razor.cs
@@ -1,21 +1,19 @@
 using System.Text.Json;
+using KidsIdKit.Core.Data;
 using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace KidsIdKit.Core.Pages.Child;
 
-public partial class ChildPhysicalDetails
+public partial class ChildPhysicalDetails : DetailsPage<Data.PhysicalDetails>
 {
     [Parameter]
     public int Id { get; set; }
     public override string MenuBarTitle { get; protected set; } = "Physical Details";
 
     private Data.ChildDetails? CurrentChild;
-    private Data.PhysicalDetails? Details;
-    private EditContext? EditContext;
-    private bool ShowPendingChangesAlert;
-    private string? originalPhysicalDetailsSnapshot;
+
     private int? snapshotChildId;
 
     protected override void OnParametersSet()
@@ -24,100 +22,25 @@ public partial class ChildPhysicalDetails
         if (child == null)
         {
             CurrentChild = null;
-            Details = null;
-            originalPhysicalDetailsSnapshot = null;
+            EditingObject = null;
+            originalSnapshot = null;
             snapshotChildId = null;
             ShowPendingChangesAlert = false;
             return;
         }
 
         CurrentChild = child.ChildDetails;
-        Details = child.PhysicalDetails;
+        EditingObject = child.PhysicalDetails;
 
-        if (snapshotChildId != Id && Details != null)
+        if (snapshotChildId != Id && EditingObject != null)
         {
-            originalPhysicalDetailsSnapshot = SerializePhysicalDetails(Details);
+            originalSnapshot = SerializeObject(EditingObject);
             snapshotChildId = Id;
             ShowPendingChangesAlert = false;
         }
     }
 
-    protected override async Task OnBackButtonClicked()
-    {
-        if (!HasPendingChanges())
-        {
-            RemoveEmptyNewChild();
-            await NavigateBack();
-            return;
-        }
-
-        ShowPendingChangesAlert = true;
-    }
-
-    private async Task SaveData() => await InternalSaveData();
-
-    private async Task OnPendingChangesAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
-    {
-        ShowPendingChangesAlert = false;
-
-        if (result.action == McmAlert.AlertAction.Confirm)
-        {
-            // Validate before saving
-            if (EditContext != null && EditContext.Validate())
-            {
-                await SaveData();
-            }
-            else
-            {
-                // Validation failed, show the alert again
-                ShowPendingChangesAlert = true;
-            }
-            return;
-        }
-
-        RestoreOriginalPhysicalDetails();
-        await NavigateBack();
-    }
-
-    private bool HasPendingChanges() =>
-        Details != null &&
-        !string.IsNullOrWhiteSpace(originalPhysicalDetailsSnapshot) &&
-        SerializePhysicalDetails(Details) != originalPhysicalDetailsSnapshot;
-
-    private void RestoreOriginalPhysicalDetails()
-    {
-        if (string.IsNullOrWhiteSpace(originalPhysicalDetailsSnapshot))
-        {
-            return;
-        }
-
-        var originalPhysicalDetails = JsonSerializer.Deserialize<Data.PhysicalDetails>(originalPhysicalDetailsSnapshot);
-        if (originalPhysicalDetails == null)
-        {
-            return;
-        }
-
-        var child = FamilyState.GetChild(Id);
-        if (child == null)
-        {
-            Details = originalPhysicalDetails;
-            return;
-        }
-
-        child.PhysicalDetails = originalPhysicalDetails;
-        Details = child.PhysicalDetails;
-
-        // If this is a newly created child (empty GivenName) and it's still in the collection,
-        // remove it since the user is discarding changes without entering a name
-        if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
-        {
-            FamilyState.Family.Children.Remove(child);
-        }
-
-        originalPhysicalDetailsSnapshot = SerializePhysicalDetails(Details);
-    }
-
-    private void RemoveEmptyNewChild()
+    protected override void RemoveAnyEmptyObjects()
     {
         var child = FamilyState.GetChild(Id);
         if (child != null && string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
@@ -126,10 +49,31 @@ public partial class ChildPhysicalDetails
         }
     }
 
-    public void SetEditContext(EditContext context)
+    protected override PhysicalDetails ResetUnalteredObject(PhysicalDetails unalteredObject)
     {
-        EditContext = context;
+        var child = FamilyState.GetChild(Id);
+        if (child == null)
+        {
+            return unalteredObject;
+        }
+
+        child.PhysicalDetails = unalteredObject;
+
+        // If this is a newly created child (empty GivenName) and it's still in the collection,
+        // remove it since the user is discarding changes without entering a name
+        if (string.IsNullOrWhiteSpace(child.ChildDetails.GivenName) && FamilyState.Family != null)
+        {
+            FamilyState.Family.Children.Remove(child);
+        }
+
+        return child.PhysicalDetails;
     }
 
-    private static string SerializePhysicalDetails(Data.PhysicalDetails physicalDetails) => JsonSerializer.Serialize(physicalDetails);
+    protected override async Task SaveData()
+    {
+        if (ValidateChangesForSave())
+        {
+            await InternalSaveData();
+        }
+    }
 }

--- a/KidsIdKit.Core/Pages/DistinguishingFeatures/ChildDistinguishingFeatureDetails.razor
+++ b/KidsIdKit.Core/Pages/DistinguishingFeatures/ChildDistinguishingFeatureDetails.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations;
 
-@inherits PageBase
+@inherits EditablePageBase<DistinguishingFeature>
 
 @{
     base.BuildRenderTree(__builder);
@@ -11,7 +11,7 @@
 
 <div class="alert-danger">@messageText</div>
 
-@if (CurrentChild == null || DistinguishingFeature == null)
+@if (CurrentChild == null || EditingObject == null)
 {
     <h2>@PageTitle</h2>
     <p>Loading...</p>
@@ -23,50 +23,55 @@ else
     <h3>@PageTitle</h3>
     <p></p>
 
-    bool photoExists = !string.IsNullOrWhiteSpace(DistinguishingFeature.Photo.ImageSource);
+    bool photoExists = !string.IsNullOrWhiteSpace(EditingObject!.Photo.ImageSource);
 
-    <EditForm Model="DistinguishingFeature" OnSubmit="SaveData">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
-        <ion-grid>
-            <EditTextRow @bind-Value="DistinguishingFeature.Description" />
-            <ion-col size="5" size-sm="3">
-                <ion-label>Photo:</ion-label>
-                                    @if (!SelectingImage)
-                    {
-                        <br />
-
-                        <br />
-                        <button class="btn btn-link" type="button" @onclick="() => SelectingImage = true">
-                            @(photoExists ? "Change" : "Add") photo
-                        </button>
-                    }
-
-            </ion-col>
-            <ion-col>
-                    @if (SelectingImage)
-                    {
-                        <PhotoPicker Complete="(selectedPhoto) =>   {
-                                                                        DistinguishingFeature.Photo = selectedPhoto;
-                                                                        SelectingImage = false;
-                                                                    }"
-                                     Cancel="() => SelectingImage = false" />
-                    }
-                    else
-                    {
-                        @if (photoExists)
+    <EditForm Model="EditingObject!" OnSubmit="SaveData" Context="editFormContext">
+        <CascadingValue Value="this">
+        @{
+            SetEditContext(editFormContext);
+        }
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <ion-grid>
+                <EditTextRow @bind-Value="EditingObject!.Description" />
+                <ion-col size="5" size-sm="3">
+                    <ion-label>Photo:</ion-label>
+                                        @if (!SelectingImage)
                         {
-                            <div>
-                                <img src="@DistinguishingFeature.Photo.ImageSource" class="img-fluid" style="max-height:40vh" title="Photo of child" alt="Photo of child" />
-                            </div>
+                            <br />
+
+                            <br />
+                            <button class="btn btn-link" type="button" @onclick="() => SelectingImage = true">
+                                @(photoExists ? "Change" : "Add") photo
+                            </button>
                         }
-                    }
-            </ion-col>
-        </ion-grid>
-        <ion-button expand="block" type="submit" color="secondary">
-            <ion-icon slot="start" name="save"></ion-icon>
-            Save
-        </ion-button>
+
+                </ion-col>
+                <ion-col>
+                        @if (SelectingImage)
+                        {
+                            <PhotoPicker Complete="(selectedPhoto) =>   {
+                                                                            EditingObject!.Photo = selectedPhoto;
+                                                                            SelectingImage = false;
+                                                                        }"
+                                         Cancel="() => SelectingImage = false" />
+                        }
+                        else
+                        {
+                            @if (photoExists)
+                            {
+                                <div>
+                                    <img src="@EditingObject!.Photo.ImageSource" class="img-fluid" style="max-height:40vh" title="Photo of child" alt="Photo of child" />
+                                </div>
+                            }
+                        }
+                </ion-col>
+            </ion-grid>
+            <ion-button expand="block" type="submit" color="secondary">
+                <ion-icon slot="start" name="save"></ion-icon>
+                Save
+            </ion-button>
+        </CascadingValue>
     </EditForm>
 }
 </ion-content>

--- a/KidsIdKit.Core/Pages/DistinguishingFeatures/ChildDistinguishingFeatureDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/DistinguishingFeatures/ChildDistinguishingFeatureDetails.razor.cs
@@ -1,4 +1,5 @@
 using KidsIdKit.Core.Data;
+using KidsIdKit.Core.Pages.SocialMediaAccounts;
 using KidsIdKit.Core.Services;
 using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
@@ -76,8 +77,15 @@ public partial class ChildDistinguishingFeatureDetails : EditablePageBase<Data.D
 
         if (child.DistinguishingFeatures.Any(f => f.Id == FeatureId))
         {
-            var index = child.DistinguishingFeatures.FindIndex(f => f.Id == unalteredObject.Id);
-            child.DistinguishingFeatures[index] = unalteredObject;
+            var index = child.DistinguishingFeatures.FindIndex(f => f.Id == FeatureId);
+            if (index >= 0)
+            {
+                child.DistinguishingFeatures[index] = unalteredObject;
+            }
+            else
+            {
+                Console.WriteLine($"Distinguishing Feature with an ID of {FeatureId} was not found.");
+            }
         }
         return unalteredObject;
     }

--- a/KidsIdKit.Core/Pages/DistinguishingFeatures/ChildDistinguishingFeatureDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/DistinguishingFeatures/ChildDistinguishingFeatureDetails.razor.cs
@@ -1,10 +1,11 @@
 using KidsIdKit.Core.Data;
 using KidsIdKit.Core.Services;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
 
 namespace KidsIdKit.Core.Pages.DistinguishingFeatures;
 
-public partial class ChildDistinguishingFeatureDetails
+public partial class ChildDistinguishingFeatureDetails : EditablePageBase<Data.DistinguishingFeature>
 {
     [Inject] private IFamilyStateService FamilyState { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
@@ -14,7 +15,7 @@ public partial class ChildDistinguishingFeatureDetails
 
     readonly string PageTitle = "Distinguishing Feature (birthmark, scar, etc.)";
     KidsIdKit.Core.Data.ChildDetails? CurrentChild;
-    DistinguishingFeature? DistinguishingFeature;
+    //DistinguishingFeature? DistinguishingFeature;
     private bool SelectingImage;
     private string? messageText;
     public override string MenuBarTitle { get; protected set; } = "Distinguishing Feature";
@@ -27,35 +28,57 @@ public partial class ChildDistinguishingFeatureDetails
 
             if (FeatureId == -1)
             {
-                DistinguishingFeature = new DistinguishingFeature();
-                DistinguishingFeature.Id = child.DistinguishingFeatures.Count == 0 ? 0 : child.DistinguishingFeatures.Max(r => r.Id) + 1;
+                EditingObject = new DistinguishingFeature();
+                EditingObject!.Id = child.DistinguishingFeatures.Count == 0 ? 0 : child.DistinguishingFeatures.Max(r => r.Id) + 1;
             }
             else if (FeatureId >= 0 && FeatureId < child.DistinguishingFeatures.Count)
             {
-                DistinguishingFeature = child.DistinguishingFeatures[FeatureId];
+                EditingObject = child.DistinguishingFeatures[FeatureId];
+            }
+            originalSnapshot = SerializeObject(EditingObject!);
+        }
+        ShowPendingChangesAlert = false;
+    }
+
+    protected override async Task SaveData()
+    {
+        messageText = string.Empty;
+        // Validate before saving
+        if (ValidateChangesForSave())
+        {
+            try
+            {
+                var child = FamilyState.GetChild(ChildId);
+                if (child != null && EditingObject is not null)
+                {
+                    if (FeatureId == -1)
+                    {
+                        child.DistinguishingFeatures.Add(EditingObject);
+                    }
+                    await FamilyState.SaveAsync();
+                }
+                await NavigateBack();
+            }
+            catch (Exception e)
+            {
+                messageText = e.Message;
             }
         }
     }
 
-    private async Task SaveData()
+    protected override DistinguishingFeature ResetUnalteredObject(DistinguishingFeature unalteredObject)
     {
-        messageText = string.Empty;
-        try
+        var child = FamilyState.GetChild(ChildId);
+        if (child == null)
         {
-            var child = FamilyState.GetChild(ChildId);
-            if (child != null && DistinguishingFeature is not null)
-            {
-                if (FeatureId == -1)
-                {
-                    child.DistinguishingFeatures.Add(DistinguishingFeature);
-                }
-                await FamilyState.SaveAsync();
-            }
-            await NavigateBack();
+            return unalteredObject;
         }
-        catch (Exception e)
+
+        if (child.DistinguishingFeatures.Any(f => f.Id == FeatureId))
         {
-            messageText = e.Message;
+            var index = child.DistinguishingFeatures.FindIndex(f => f.Id == unalteredObject.Id);
+            child.DistinguishingFeatures[index] = unalteredObject;
         }
+        return unalteredObject;
     }
 }

--- a/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor
+++ b/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor
@@ -7,7 +7,7 @@
 @inject IFamilyStateService FamilyState
 @inject NavigationManager NavigationManager
 
-@inherits PageBase
+@inherits EditablePageBase<FamilyMember>
 
 @{
     base.BuildRenderTree(__builder);
@@ -15,7 +15,7 @@
 <ion-content class="ion-padding">
 <div class="alert-danger">@messageText</div>
 
-@if (CurrentChild == null || Family == null)
+@if (CurrentChild == null || EditingObject == null)
 {
     <h2>Family Member</h2>
     <p>Loading...</p>
@@ -26,22 +26,27 @@ else
     <p></p>
     <h3>Family Member</h3>
     <p></p>
-    <EditForm Model="Family" OnSubmit="SaveData">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
-        <ion-grid>
-            <EditTextRow @bind-Value="Family.GivenName" />
-            <EditTextRow @bind-Value="Family.NickName" />
-            <EditTextRow @bind-Value="Family.FamilyName" />
-            <EditTextRow @bind-Value="Family.Relation" />
-            <EditTextRow @bind-Value="Family.Address" />
-            <EditTextRow @bind-Value="Family.PhoneNumber" />
-        </ion-grid>
+    <EditForm Model="EditingObject!" OnSubmit="SaveData" Context="editFormContext">
+        <CascadingValue Value="this">
+            @{
+                SetEditContext(editFormContext);
+            }
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <ion-grid>
+                <EditTextRow @bind-Value="EditingObject!.GivenName" />
+                <EditTextRow @bind-Value="EditingObject!.NickName" />
+                <EditTextRow @bind-Value="EditingObject!.FamilyName" />
+                <EditTextRow @bind-Value="EditingObject!.Relation" />
+                <EditTextRow @bind-Value="EditingObject!.Address" />
+                <EditTextRow @bind-Value="EditingObject!.PhoneNumber" />
+            </ion-grid>
 
-        <ion-button expand="block" type="submit" color="secondary">
-            <ion-icon slot="start" name="save"></ion-icon>
-            Save
-        </ion-button>
+            <ion-button expand="block" type="submit" color="secondary">
+                <ion-icon slot="start" name="save"></ion-icon>
+                Save
+            </ion-button>
+        </CascadingValue>
     </EditForm>
 }
 </ion-content>

--- a/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor.cs
@@ -44,8 +44,15 @@ public partial class ChildFamilyMemberDetails : EditablePageBase<Data.FamilyMemb
 
         if (child.FamilyMembers.Any(f => f.Id == FamilyId))
         {
-            var index = child.FamilyMembers.FindIndex(f => f.Id == unalteredObject.Id);
-            child.FamilyMembers[index] = unalteredObject;
+            var index = child.FamilyMembers.FindIndex(f => f.Id == FamilyId);
+            if (index >= 0)
+            {
+                child.FamilyMembers[index] = unalteredObject;
+            }
+            else
+            {
+                Console.WriteLine($"Family member with an ID of {FamilyId} was not found");
+            }
         }
         return unalteredObject;
     }

--- a/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor.cs
@@ -1,59 +1,77 @@
 ﻿using KidsIdKit.Core.Data;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace KidsIdKit.Core.Pages.FamilyMembers;
 
-public partial class ChildFamilyMemberDetails
+public partial class ChildFamilyMemberDetails : EditablePageBase<Data.FamilyMember>
 {
-    [Parameter] public int childId { get; set; }
-    [Parameter] public int familyId { get; set; }
+    [Parameter] public int ChildId { get; set; }
+    [Parameter] public int FamilyId { get; set; }
 
-    ChildDetails? CurrentChild;
-    FamilyMember? Family;
+    Data.ChildDetails? CurrentChild;
     private string? messageText;
     public override string MenuBarTitle { get; protected set; } = "Family Member";
     
     protected override void OnInitialized()
     {
-        var child = FamilyState.GetChild(childId);
+        var child = FamilyState.GetChild(ChildId);
         if (child != null)
         {
             CurrentChild = child.ChildDetails;
 
-            if (familyId == -1)
+            if (FamilyId == -1)
             {
-                Family = new FamilyMember();
-                Family.Id = child.FamilyMembers.Count == 0 ? 0 : child.FamilyMembers.Max(r => r.Id) + 1;
+                EditingObject = new FamilyMember();
+                EditingObject.Id = child.FamilyMembers.Count == 0 ? 0 : child.FamilyMembers.Max(r => r.Id) + 1;
             }
-            else if (familyId >= 0 && familyId < child.FamilyMembers.Count)
+            else if (FamilyId >= 0 && FamilyId < child.FamilyMembers.Count)
             {
-                Family = child.FamilyMembers[familyId];
+                EditingObject = child.FamilyMembers[FamilyId];
             }
+            originalSnapshot = SerializeObject(EditingObject!);
         }
+        ShowPendingChangesAlert = false;
     }
 
-    private async Task SaveData()
+    protected override FamilyMember ResetUnalteredObject(FamilyMember unalteredObject)
+    {
+        var child = FamilyState.GetChild(ChildId);
+        if (child == null)
+        {
+            return unalteredObject;
+        }
+
+        if (child.FamilyMembers.Any(f => f.Id == FamilyId))
+        {
+            var index = child.FamilyMembers.FindIndex(f => f.Id == unalteredObject.Id);
+            child.FamilyMembers[index] = unalteredObject;
+        }
+        return unalteredObject;
+    }
+
+    protected override async Task SaveData()
     {
         messageText = string.Empty;
-        try
+        if (ValidateChangesForSave())
         {
-            var child = FamilyState.GetChild(childId);
-            if (child != null && Family is not null)
+            try
             {
-                if (familyId == -1)
+                var child = FamilyState.GetChild(ChildId);
+                if (child != null && EditingObject is not null)
                 {
-                    child.FamilyMembers.Add(Family);
+                    if (FamilyId == -1)
+                    {
+                        child.FamilyMembers.Add(EditingObject);
+                    }
+                    await FamilyState.SaveAsync();
                 }
-                await FamilyState.SaveAsync();
+                await NavigateBack();
             }
-            await NavigateBack();
-        }
-        catch (Exception e)
-        {
-            messageText = e.Message;
+            catch (Exception e)
+            {
+                messageText = e.Message;
+            }
         }
     }
 }

--- a/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/FamilyMembers/ChildFamilyMemberDetails.razor.cs
@@ -23,11 +23,19 @@ public partial class ChildFamilyMemberDetails : EditablePageBase<Data.FamilyMemb
             if (FamilyId == -1)
             {
                 EditingObject = new FamilyMember();
-                EditingObject.Id = child.FamilyMembers.Count == 0 ? 0 : child.FamilyMembers.Max(r => r.Id) + 1;
+                EditingObject!.Id = child.FamilyMembers.Count == 0 ? 0 : child.FamilyMembers.Max(r => r.Id) + 1;
             }
-            else if (FamilyId >= 0 && FamilyId < child.FamilyMembers.Count)
+            else if (FamilyId >= 0)
             {
-                EditingObject = child.FamilyMembers[FamilyId];
+                var index = child.FamilyMembers.FindIndex(f => f.Id == FamilyId);
+                if (index >= 0)
+                {
+                    EditingObject = child.FamilyMembers[index];
+                }
+                else
+                {
+                    Console.WriteLine($"Family member with an ID of {FamilyId} was not found");
+                }
             }
             originalSnapshot = SerializeObject(EditingObject!);
         }

--- a/KidsIdKit.Core/Pages/Friends/ChildFriendDetails.razor
+++ b/KidsIdKit.Core/Pages/Friends/ChildFriendDetails.razor
@@ -7,7 +7,7 @@
 @inject IFamilyStateService FamilyState
 @inject NavigationManager NavigationManager
 
-@inherits PageBase
+@inherits EditablePageBase<Data.Person>
 
 @{
     base.BuildRenderTree(__builder);
@@ -17,7 +17,7 @@
 
 <div class="alert-danger">@messageText</div>
 
-@if (CurrentChild == null || Friend == null)
+@if (CurrentChild == null || EditingObject == null)
 {
     <ion-spinner></ion-spinner>
     <p>Loading...</p>
@@ -27,25 +27,28 @@ else
     <ion-text><h2>@CurrentChild.FullName</h2></ion-text>
     <ion-text><h3>Friend</h3></ion-text>
 
-    <EditForm Model="Friend" OnSubmit="SaveData">
-        <DataAnnotationsValidator />
+    <EditForm Model="EditingObject" OnSubmit="SaveData" Context="editFormContext">
+        <CascadingValue Value="this">
+            @{
+                SetEditContext(editFormContext);
+            }
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <ion-grid>
+                <EditTextRow @bind-Value="EditingObject!.GivenName" />
+                <EditTextRow @bind-Value="EditingObject!.NickName" />
+                <EditTextRow @bind-Value="EditingObject!.FamilyName" />
+                <EditTextRow @bind-Value="EditingObject!.Address" />
+                <EditTextRow @bind-Value="EditingObject!.PhoneNumber" />
+            </ion-grid>
 
-        <ValidationSummary />
-
-        <ion-grid>
-            <EditTextRow @bind-Value="Friend.GivenName" />
-            <EditTextRow @bind-Value="Friend.NickName" />
-            <EditTextRow @bind-Value="Friend.FamilyName" />
-            <EditTextRow @bind-Value="Friend.Address" />
-            <EditTextRow @bind-Value="Friend.PhoneNumber" />
-        </ion-grid>
-
-        <div class="ion-padding">
-            <ion-button expand="block" type="submit" color="secondary">
-                <ion-icon slot="start" name="save"></ion-icon>
-                Save
-            </ion-button>
-        </div>
+            <div class="ion-padding">
+                <ion-button expand="block" type="submit" color="secondary">
+                    <ion-icon slot="start" name="save"></ion-icon>
+                    Save
+                </ion-button>
+            </div>
+        </CascadingValue>
     </EditForm>
 }
 </ion-content>

--- a/KidsIdKit.Core/Pages/Friends/ChildFriendDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Friends/ChildFriendDetails.razor.cs
@@ -1,4 +1,5 @@
 ﻿using KidsIdKit.Core.Data;
+using KidsIdKit.Core.Pages.SocialMediaAccounts;
 using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
 
@@ -25,9 +26,17 @@ public partial class ChildFriendDetails : EditablePageBase<Data.Person>
                 EditingObject = new Person();
                 EditingObject!.Id = child.Friends.Count == 0 ? 0 : child.Friends.Max(r => r.Id) + 1;
             }
-            else if (FriendId >= 0 && FriendId < child.Friends.Count)
+            else if (FriendId >= 0)
             {
-                EditingObject = child.Friends[FriendId];
+                var index = child.Friends.FindIndex(f => f.Id == FriendId);
+                if (index >= 0)
+                {
+                    EditingObject = child.Friends[index];
+                }
+                else
+                {
+                    Console.WriteLine($"Friend with an ID of {FriendId} was not found.");
+                }    
             }
             originalSnapshot = SerializeObject(EditingObject!);
         }
@@ -44,8 +53,15 @@ public partial class ChildFriendDetails : EditablePageBase<Data.Person>
 
         if (child.Friends.Any(f => f.Id == FriendId))
         {
-            var index = child.Friends.FindIndex(f => f.Id == unalteredObject.Id);
-            child.Friends[index] = unalteredObject;
+            var index = child.Friends.FindIndex(f => f.Id == FriendId);
+            if (index >= 0)
+            {
+                child.Friends[index] = unalteredObject;
+            }
+            else
+            {
+                Console.WriteLine($"Friend with an ID of {FriendId} was not found.");
+            }
         }
         return unalteredObject;
     }

--- a/KidsIdKit.Core/Pages/Friends/ChildFriendDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/Friends/ChildFriendDetails.razor.cs
@@ -1,56 +1,78 @@
 ﻿using KidsIdKit.Core.Data;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
 
 namespace KidsIdKit.Core.Pages.Friends;
 
-public partial class ChildFriendDetails
+public partial class ChildFriendDetails : EditablePageBase<Data.Person>
 {
-    [Parameter] public int childId { get; set; }
-    [Parameter] public int friendId { get; set; }
+    [Parameter] public int ChildId { get; set; }
+    [Parameter] public int FriendId { get; set; }
 
     ChildDetails? CurrentChild;
-    Person? Friend;
     private string? messageText;
     public override string MenuBarTitle { get; protected set; } = "Friend";
 
     protected override void OnInitialized()
     {
-        var child = FamilyState.GetChild(childId);
+        var child = FamilyState.GetChild(ChildId);
         if (child != null)
         {
             CurrentChild = child.ChildDetails;
 
-            if (friendId == -1)
+            if (FriendId == -1)
             {
-                Friend = new Person();
-                Friend.Id = child.Friends.Count == 0 ? 0 : child.Friends.Max(r => r.Id) + 1;
+                EditingObject = new Person();
+                EditingObject!.Id = child.Friends.Count == 0 ? 0 : child.Friends.Max(r => r.Id) + 1;
             }
-            else if (friendId >= 0 && friendId < child.Friends.Count)
+            else if (FriendId >= 0 && FriendId < child.Friends.Count)
             {
-                Friend = child.Friends[friendId];
+                EditingObject = child.Friends[FriendId];
             }
+            originalSnapshot = SerializeObject(EditingObject!);
         }
+        ShowPendingChangesAlert = false;
     }
 
-    private async Task SaveData()
+    protected override Person ResetUnalteredObject(Person unalteredObject)
+    {
+        var child = FamilyState.GetChild(ChildId);
+        if (child == null)
+        {
+            return unalteredObject;
+        }
+
+        if (child.Friends.Any(f => f.Id == FriendId))
+        {
+            var index = child.Friends.FindIndex(f => f.Id == unalteredObject.Id);
+            child.Friends[index] = unalteredObject;
+        }
+        return unalteredObject;
+    }
+
+    protected override async Task SaveData()
     {
         messageText = string.Empty;
-        try
+        // Validate before saving
+        if (ValidateChangesForSave())
         {
-            var child = FamilyState.GetChild(childId);
-            if (child != null && Friend is not null)
+            try
             {
-                if (friendId == -1)
+                var child = FamilyState.GetChild(ChildId);
+                if (child != null && EditingObject is not null)
                 {
-                    child.Friends.Add(Friend);
+                    if (FriendId == -1)
+                    {
+                        child.Friends.Add(EditingObject);
+                    }
+                    await FamilyState.SaveAsync();
                 }
-                await FamilyState.SaveAsync();
+                await NavigateBack();
             }
-            await NavigateBack();
-        }
-        catch (Exception e)
-        {
-            messageText = e.Message;
+            catch (Exception e)
+            {
+                messageText = e.Message;
+            }
         }
     }
 }

--- a/KidsIdKit.Core/Pages/SocialMediaAccounts/SocialMediaAccountDetails.razor
+++ b/KidsIdKit.Core/Pages/SocialMediaAccounts/SocialMediaAccountDetails.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations;
 
-@inherits PageBase
+@inherits EditablePageBase<Data.SocialMediaAccount>
 
 @{
 base.BuildRenderTree(__builder);
@@ -11,7 +11,7 @@ base.BuildRenderTree(__builder);
 <ion-content class="ion-padding">
 <div class="alert-danger">@messageText</div>
 
-@if (CurrentChild == null || SocialMediaAccount == null)
+@if (CurrentChild == null || EditingObject == null)
 {
     <ion-spinner></ion-spinner>
     <p>Loading...</p>
@@ -21,21 +21,26 @@ else
     <ion-text><h2>@CurrentChild.FullName</h2></ion-text>
     <ion-text><h3>Social Media Account</h3></ion-text>
 
-    <EditForm Model="SocialMediaAccount" OnSubmit="SaveData">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
-        <ion-grid>
-            <EditTextRow @bind-Value="SocialMediaAccount.Platform" />
-            <EditTextRow @bind-Value="SocialMediaAccount.UserName" />
-            <EditTextRow @bind-Value="SocialMediaAccount.Password" IsPassword="true" />
-        </ion-grid>
+    <EditForm Model="EditingObject" OnSubmit="SaveData" Context="editFormContext">
+        <CascadingValue Value="this">
+            @{
+                SetEditContext(editFormContext);
+            }
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <ion-grid>
+                <EditTextRow @bind-Value="EditingObject!.Platform" />
+                <EditTextRow @bind-Value="EditingObject!.UserName" />
+                <EditTextRow @bind-Value="EditingObject!.Password" IsPassword="true" />
+            </ion-grid>
 
-        <div class="ion-padding">
-            <ion-button expand="block" type="submit" color="secondary">
-                <ion-icon slot="start" name="save"></ion-icon>
-                Save
-            </ion-button>
-        </div>
+            <div class="ion-padding">
+                <ion-button expand="block" type="submit" color="secondary">
+                    <ion-icon slot="start" name="save"></ion-icon>
+                    Save
+                </ion-button>
+            </div>
+        </CascadingValue>
     </EditForm>
 }
 </ion-content>

--- a/KidsIdKit.Core/Pages/SocialMediaAccounts/SocialMediaAccountDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/SocialMediaAccounts/SocialMediaAccountDetails.razor.cs
@@ -34,7 +34,15 @@ public partial class SocialMediaAccountDetails : EditablePageBase<Data.SocialMed
             }
             else if (SocialMediaAccountId >= 0 && SocialMediaAccountId < child.SocialMediaAccounts.Count)
             {
-                EditingObject = child.SocialMediaAccounts[SocialMediaAccountId];
+                var index = child.SocialMediaAccounts.FindIndex(f => f.Id == SocialMediaAccountId);
+                if (index >= 0)
+                {
+                    EditingObject = child.SocialMediaAccounts[index];
+                }
+                else
+                {
+                    Console.WriteLine($"Social media account with an ID of {SocialMediaAccountId} was not found.");
+                }
             }
 
             if (EditingObject != null)

--- a/KidsIdKit.Core/Pages/SocialMediaAccounts/SocialMediaAccountDetails.razor.cs
+++ b/KidsIdKit.Core/Pages/SocialMediaAccounts/SocialMediaAccountDetails.razor.cs
@@ -1,61 +1,88 @@
 using KidsIdKit.Core.Data;
+using KidsIdKit.Core.Pages.Child;
 using KidsIdKit.Core.Services;
+using KidsIdKit.Core.SharedComponents;
 using Microsoft.AspNetCore.Components;
 
 namespace KidsIdKit.Core.Pages.SocialMediaAccounts;
 
-public partial class SocialMediaAccountDetails
+public partial class SocialMediaAccountDetails : EditablePageBase<Data.SocialMediaAccount>
 {
     [Inject] private IFamilyStateService FamilyState { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
 
-    [Parameter] public int childId { get; set; }
-    [Parameter] public int socialMediaAccountId { get; set; }
+    [Parameter] public int ChildId { get; set; }
+    [Parameter] public int SocialMediaAccountId { get; set; }
 
-    ChildDetails? CurrentChild;
-    SocialMediaAccount? SocialMediaAccount;
+    Data.ChildDetails? CurrentChild;
+
     private string? messageText;
     // TODO: Extract "Social Media Account" from .razor file to a PageTitle field
     public override string MenuBarTitle { get; protected set; } = "Social Media";
 
     protected override void OnInitialized()
     {
-        var child = FamilyState.GetChild(childId);
+        var child = FamilyState.GetChild(ChildId);
         if (child != null)
         {
             CurrentChild = child.ChildDetails;
 
-            if (socialMediaAccountId == -1)
+            if (SocialMediaAccountId == -1)
             {
-                SocialMediaAccount = new SocialMediaAccount();
-                SocialMediaAccount.Id = child.SocialMediaAccounts.Count == 0 ? 0 : child.SocialMediaAccounts.Max(r => r.Id) + 1;
+                EditingObject = new SocialMediaAccount();
+                EditingObject.Id = child.SocialMediaAccounts.Count == 0 ? 0 : child.SocialMediaAccounts.Max(r => r.Id) + 1;
             }
-            else if (socialMediaAccountId >= 0 && socialMediaAccountId < child.SocialMediaAccounts.Count)
+            else if (SocialMediaAccountId >= 0 && SocialMediaAccountId < child.SocialMediaAccounts.Count)
             {
-                SocialMediaAccount = child.SocialMediaAccounts[socialMediaAccountId];
+                EditingObject = child.SocialMediaAccounts[SocialMediaAccountId];
+            }
+
+            if (EditingObject != null)
+            {
+                originalSnapshot = SerializeObject(EditingObject);
+                ShowPendingChangesAlert = false;
             }
         }
     }
 
-    private async Task SaveData()
+    protected override SocialMediaAccount ResetUnalteredObject(SocialMediaAccount unalteredObject)
+    {
+        var child = FamilyState.GetChild(ChildId);
+        if (child == null)
+        {
+            return unalteredObject;
+        }
+
+        if (child.SocialMediaAccounts.Any(f => f.Id == SocialMediaAccountId))
+        {
+            var index = child.SocialMediaAccounts.FindIndex(f => f.Id == unalteredObject.Id);
+            child.SocialMediaAccounts[index] = unalteredObject;
+        }
+        return unalteredObject;
+    }
+
+    protected override async Task SaveData()
     {
         messageText = string.Empty;
-        try
+        if (ValidateChangesForSave())
         {
-            var child = FamilyState.GetChild(childId);
-            if (child != null && SocialMediaAccount is not null)
+            try
             {
-                if (socialMediaAccountId == -1)
+                var child = FamilyState.GetChild(ChildId);
+                if (child != null && EditingObject is not null)
                 {
-                    child.SocialMediaAccounts.Add(SocialMediaAccount);
+                    if (SocialMediaAccountId == -1)
+                    {
+                        child.SocialMediaAccounts.Add(EditingObject);
+                    }
+                    await FamilyState.SaveAsync();
                 }
-                await FamilyState.SaveAsync();
+                await NavigateBack();
             }
-            await NavigateBack();
-        }
-        catch (Exception e)
-        {
-            messageText = e.Message;
+            catch (Exception e)
+            {
+                messageText = e.Message;
+            }
         }
     }
 }

--- a/KidsIdKit.Core/SharedComponents/DetailsPage.razor
+++ b/KidsIdKit.Core/SharedComponents/DetailsPage.razor
@@ -1,6 +1,10 @@
 @using KidsIdKit.Core.Data
 @using KidsIdKit.Core.Services
 
+@inherits EditablePageBase<T>
+
+@typeparam T where T : class
+
 @{
 base.BuildRenderTree(__builder);
 }

--- a/KidsIdKit.Core/SharedComponents/DetailsPage.razor
+++ b/KidsIdKit.Core/SharedComponents/DetailsPage.razor
@@ -1,10 +1,6 @@
 @using KidsIdKit.Core.Data
 @using KidsIdKit.Core.Services
 
-@inherits PageBase
-
-@inject IJSRuntime JSRuntime
-
 @{
 base.BuildRenderTree(__builder);
 }

--- a/KidsIdKit.Core/SharedComponents/DetailsPage.razor.cs
+++ b/KidsIdKit.Core/SharedComponents/DetailsPage.razor.cs
@@ -2,15 +2,18 @@
 using KidsIdKit.Core.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace KidsIdKit.Core.SharedComponents;
 
-public abstract partial class DetailsPage
+public abstract partial class DetailsPage<T> : EditablePageBase<T> where T : class
 {
     [Inject]
     protected NavigationManager NavigationManager { get; set; } = default!;
     [Inject]
     protected IFamilyStateService FamilyState { get; set; } = default!;
+    [Inject] 
+    protected IJSRuntime JSRuntime { get; set; } = default!;
 
     protected string? messageText;
     protected bool isError;

--- a/KidsIdKit.Core/SharedComponents/DetailsPage.razor.cs
+++ b/KidsIdKit.Core/SharedComponents/DetailsPage.razor.cs
@@ -2,7 +2,6 @@
 using KidsIdKit.Core.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace KidsIdKit.Core.SharedComponents;
 

--- a/KidsIdKit.Core/SharedComponents/EditablePageBase.razor
+++ b/KidsIdKit.Core/SharedComponents/EditablePageBase.razor
@@ -1,0 +1,20 @@
+﻿@inherits PageBase
+
+@typeparam T where T : class
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+<McmAlert Header="Unsaved changes"
+          Message="Do you want to save your pending changes or discard them?"
+          ConfirmPrompt="Save"
+          CancelPrompt="Discard"
+          Show="ShowPendingChangesAlert"
+          AlertClosed="OnPendingChangesAlertClosed" />
+
+<McmAlert Header="Error Saving"
+          Message="The current data is not valid and this item cannot be saved."
+          CancelPrompt="OK"
+          Show="CannotSaveChangesAlert"
+          AlertClosed="OnCannotSaveAlertClosed" />

--- a/KidsIdKit.Core/SharedComponents/EditablePageBase.razor.cs
+++ b/KidsIdKit.Core/SharedComponents/EditablePageBase.razor.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.AspNetCore.Components.Forms;
+using System.Text.Json;
+
+namespace KidsIdKit.Core.SharedComponents;
+
+public abstract partial class EditablePageBase<T>: PageBase where T : class
+{
+    protected bool ShowPendingChangesAlert = false;
+    protected bool CannotSaveChangesAlert = false;
+    protected EditContext? EditContext { get; set; }
+    protected string? originalSnapshot;
+    protected T? EditingObject { get; set; }
+
+    protected override async Task OnBackButtonClicked()
+    {
+        if (!HasPendingChanges())
+        {
+            RemoveAnyEmptyObjects();
+            await NavigateBack();
+            return;
+        }
+
+        ShowPendingChangesAlert = true;
+    }
+
+    protected virtual async Task OnPendingChangesAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
+    {
+        ShowPendingChangesAlert = false;
+
+        if (result.action == McmAlert.AlertAction.Confirm)
+        {
+            await SaveData();
+            return;
+        }
+
+        RestoreOriginalObject();
+        await NavigateBack();
+    }
+
+    protected virtual bool ValidateChangesForSave()
+    {
+        bool isValid = false;
+        if (EditContext == null)
+            isValid = true;
+        else if (EditContext.Validate())
+        {
+            isValid = true;
+        }
+        CannotSaveChangesAlert = true;
+        return isValid;
+    }
+
+    protected virtual async Task OnCannotSaveAlertClosed((McmAlert.AlertAction action, string stateInformation) result)
+    {
+        CannotSaveChangesAlert = false;
+    }
+
+    protected virtual void RestoreOriginalObject()
+    {
+        if (string.IsNullOrWhiteSpace(originalSnapshot))
+        {
+            return;
+        }
+
+        var unalteredObject = JsonSerializer.Deserialize<T>(originalSnapshot);
+        if (unalteredObject == null)
+        {
+            return;
+        }
+
+        EditingObject = ResetUnalteredObject(unalteredObject);
+
+        if (EditingObject != null)
+        {
+            originalSnapshot = SerializeObject(EditingObject);
+        }
+    }
+
+
+    protected virtual bool HasPendingChanges() =>
+        EditingObject != null &&
+        !string.IsNullOrWhiteSpace(originalSnapshot) &&
+        SerializeObject(EditingObject) != originalSnapshot;
+
+    protected virtual void RemoveAnyEmptyObjects() { }
+
+    protected abstract T ResetUnalteredObject(T unalteredObject);
+
+    protected abstract Task SaveData();
+
+    public void SetEditContext(EditContext context)
+    {
+        EditContext = context;
+    }
+
+    protected static string SerializeObject(T targetObject) => JsonSerializer.Serialize(targetObject);
+}

--- a/KidsIdKit.Core/SharedComponents/EditablePageBase.razor.cs
+++ b/KidsIdKit.Core/SharedComponents/EditablePageBase.razor.cs
@@ -39,14 +39,12 @@ public abstract partial class EditablePageBase<T>: PageBase where T : class
 
     protected virtual bool ValidateChangesForSave()
     {
-        bool isValid = false;
-        if (EditContext == null)
-            isValid = true;
-        else if (EditContext.Validate())
+        bool isValid = EditContext == null || EditContext.Validate() ? true : false;
+
+        if (!isValid)
         {
-            isValid = true;
+            CannotSaveChangesAlert = true;
         }
-        CannotSaveChangesAlert = true;
         return isValid;
     }
 

--- a/KidsIdKit.Core/SharedComponents/PageBase.razor
+++ b/KidsIdKit.Core/SharedComponents/PageBase.razor
@@ -6,7 +6,7 @@
 <ion-header>
     <ion-toolbar color="primary">
         <ion-buttons slot="start">
-            <ion-button size="small" style="--box-shadow: none" @onclick="NavigateBack">
+            <ion-button size="small" style="--box-shadow: none" @onclick="OnBackButtonClicked">
                 <ion-back-button default-href="/"></ion-back-button>
             </ion-button>
         </ion-buttons>

--- a/KidsIdKit.Core/SharedComponents/PageBase.razor.cs
+++ b/KidsIdKit.Core/SharedComponents/PageBase.razor.cs
@@ -1,13 +1,15 @@
 ﻿using Microsoft.JSInterop;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace KidsIdKit.Core.SharedComponents;
 
 public abstract partial class PageBase
 {
     public abstract string MenuBarTitle { get; protected set; }
+
+    protected virtual async Task OnBackButtonClicked()
+    {
+        await NavigateBack();
+    }
 
     protected async Task NavigateBack()
     {

--- a/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
+++ b/KidsIdKit.Mobile/KidsIdKit.Mobile.csproj
@@ -129,7 +129,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="npm_modules\" />
+      <Content Remove="npm_modules\*" />
 	</ItemGroup>
 
     <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
Add unsaved changes detection to ChildDetails, ChildMedicalNotes, and ChildPhysicalDetails pages. Show confirmation dialog on back navigation if there are pending changes, allowing users to save or discard. Track original form state via JSON serialization. Refactor to use EditContext and encapsulate state management. Update PageBase to support overridable back button logic. Add McmAlert UI and context sharing for forms.

Tested the following:

- When creating a new record in the Child Details, Child Physical Details, and/or Child Medical Notes page, if the user entered at least 1 character, then tried to navigate back, and decided to save the changes, the app needs to check that all required fields have been entered - just as if they tapped the [SAVE] button in a regular edit session.
- When creating a new record in the Child Details, Child Physical Details, and/or Child Medical Notes page, if the user entered at least 1 character, then tried to navigate back, and decided to discard the changes, the app needs to remove the new object from the collection it had added.
- When creating a new record in the Child Details, Child Physical Details, and/or Child Medical Notes page, if the user immediately navigates back (in other words, he/she didn't even enter at least 1 character), the app needs to also remove the new object from the collection it had added.

This resolves [Pull Request 168](https://github.com/missingchildrenmn/KidsIdKit/issues/168).