### PR TITLE
Remove unneeded permission from app

### DIFF
--- a/KidsIdKit.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/KidsIdKit.Mobile/Platforms/Android/AndroidManifest.xml
@@ -9,7 +9,6 @@
 	<uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />


### PR DESCRIPTION
Play Store kicked out the release due to an unneeded permission in the application for access to photos. I removed the permission and ensured the photo picker within the app was still working correctly.